### PR TITLE
Add null handling support

### DIFF
--- a/benchmarks/MapTo.Benchmarks/MapTo.Benchmarks.csproj
+++ b/benchmarks/MapTo.Benchmarks/MapTo.Benchmarks.csproj
@@ -5,7 +5,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
-        <EmitCompilerGeneratedFiles>false</EmitCompilerGeneratedFiles>
+        <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
 
         <MapTo_ReferenceHandling>Disabled</MapTo_ReferenceHandling>
     </PropertyGroup>
@@ -15,6 +15,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
         <None Update="Data\SpotifyAlbum.json">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>

--- a/src/MapTo.Abstractions/MapFromAttribute.cs
+++ b/src/MapTo.Abstractions/MapFromAttribute.cs
@@ -53,4 +53,10 @@ public sealed class MapFromAttribute : Attribute
     /// </summary>
     /// <value>The name of the method to call after mapping the property.</value>
     public string? AfterMap { get; set; }
+
+    /// <summary>
+    /// Gets or sets the way to handle null properties.
+    /// </summary>
+    /// <value>The way to handle null properties.</value>
+    public NullHandling NullHandling { get; set; } = NullHandling.Auto;
 }

--- a/src/MapTo.Abstractions/MapPropertyAttribute.cs
+++ b/src/MapTo.Abstractions/MapPropertyAttribute.cs
@@ -11,4 +11,9 @@ public sealed class MapPropertyAttribute : Attribute
     /// </summary>
     /// <value>The name of the source property to map to.</value>
     public string? From { get; set; }
+
+    /// <summary>
+    /// Gets or sets the way to handle null properties.
+    /// </summary>
+    public NullHandling NullHandling { get; set; } = NullHandling.Auto;
 }

--- a/src/MapTo.Abstractions/NullHandling.cs
+++ b/src/MapTo.Abstractions/NullHandling.cs
@@ -1,0 +1,45 @@
+﻿namespace MapTo;
+
+/// <summary>
+/// Specifies how to handle null properties.
+/// </summary>
+public enum NullHandling
+{
+    /// <summary>
+    /// Indicates that the <c>null</c> values should be handled based on the source and target nullability context.
+    /// </summary>
+    /// <remarks>
+    /// When Nullability context is <b>disabled</b>: All <c>null</c> checks are ignored and the target property will be the same as the source property.
+    /// This is equivalent to <see cref="SetNull" /> option.
+    /// <para>
+    /// When Nullability context is <b>enabled</b>:
+    /// <list type="bullet">
+    ///     <item>If both target and source are nullable, no null check will be performed and the target will be the same as the source.</item>
+    ///     <item>
+    ///     If the target is nullable but the source is not, no null check will be performed and the target will be the same as the source unless a
+    ///     <see cref="PropertyTypeConverterAttribute" />
+    ///     is specified on the target property, in which case the converter's return value's nullability context will be used.
+    ///     </item>
+    ///     <item>If the target is not nullable but the source is, for collections target will be empty collection; for other types reports diagnostic.</item>
+    ///     <item>If both target and source are not nullable, no null check will be performed and the target will be the same as the source.</item>
+    /// </list>
+    /// </para>
+    /// </remarks>
+    Auto,
+
+    /// <summary>
+    /// Indicates that if the source is <c>null</c>, the target will be <c>null</c> too, regardless of its nullability context.
+    /// </summary>
+    SetNull,
+
+    /// <summary>
+    /// Indicates that if the source collection is <c>null</c>, the target collection will be empty, regardless of its nullability context.
+    /// This option is only valid for collections.
+    /// </summary>
+    SetEmptyCollection,
+
+    /// <summary>
+    /// Indicates to throw an <see cref="ArgumentNullException" /> if the source is nullable but the target is not.
+    /// </summary>
+    ThrowException
+}

--- a/src/MapTo.Abstractions/PublicAPI.Shipped.txt
+++ b/src/MapTo.Abstractions/PublicAPI.Shipped.txt
@@ -19,12 +19,21 @@ MapTo.MapFromAttribute.MapFromAttribute(System.Type! sourceType) -> void
 MapTo.MapFromAttribute.ReferenceHandling.get -> MapTo.Configuration.ReferenceHandling
 MapTo.MapFromAttribute.ReferenceHandling.set -> void
 MapTo.MapFromAttribute.SourceType.get -> System.Type!
+MapTo.MapFromAttribute.NullHandling.get -> MapTo.NullHandling
+MapTo.MapFromAttribute.NullHandling.set -> void
 MapTo.MapPropertyAttribute
 MapTo.MapPropertyAttribute.From.get -> string?
 MapTo.MapPropertyAttribute.From.set -> void
+MapTo.MapPropertyAttribute.NullHandling.get -> MapTo.NullHandling
+MapTo.MapPropertyAttribute.NullHandling.set -> void
 MapTo.MapPropertyAttribute.MapPropertyAttribute() -> void
 MapTo.PropertyTypeConverterAttribute
 MapTo.PropertyTypeConverterAttribute.MethodName.get -> string!
 MapTo.PropertyTypeConverterAttribute.Parameters.get -> object![]?
 MapTo.PropertyTypeConverterAttribute.Parameters.set -> void
 MapTo.PropertyTypeConverterAttribute.PropertyTypeConverterAttribute(string! methodName) -> void
+MapTo.NullHandling
+MapTo.NullHandling.Auto = 0 -> MapTo.NullHandling
+MapTo.NullHandling.SetNull = 1 -> MapTo.NullHandling
+MapTo.NullHandling.SetEmptyCollection = 2 -> MapTo.NullHandling
+MapTo.NullHandling.ThrowException = 3 -> MapTo.NullHandling

--- a/src/MapTo/CodeAnalysis/CompilationExtensions.cs
+++ b/src/MapTo/CodeAnalysis/CompilationExtensions.cs
@@ -18,6 +18,11 @@ internal static class CompilationExtensions
         typeSymbol is INamedTypeSymbol { IsGenericType: true } &&
         compilation.GetSpecialType(SpecialType.System_Collections_Generic_IEnumerable_T).Equals(typeSymbol.OriginalDefinition, SymbolEqualityComparer.Default);
 
+    public static bool IsNonGenericEnumerable(this Compilation compilation, ITypeSymbol typeSymbol) =>
+        typeSymbol is INamedTypeSymbol { IsGenericType: false } &&
+        !SymbolEqualityComparer.Default.Equals(compilation.GetSpecialType(SpecialType.System_String), typeSymbol) &&
+        compilation.HasImplicitConversion(typeSymbol, compilation.GetSpecialType(SpecialType.System_Collections_IEnumerable));
+
     public static bool TypeByMetadataNameExists(this Compilation? compilation, string typeMetadataName) => GetTypesByMetadataName(compilation, typeMetadataName).Any();
 
     public static IEnumerable<INamedTypeSymbol> GetTypesByMetadataName(this Compilation? compilation, string typeMetadataName)

--- a/src/MapTo/Configuration/CodeGeneratorOptions.cs
+++ b/src/MapTo/Configuration/CodeGeneratorOptions.cs
@@ -9,11 +9,13 @@ namespace MapTo.Configuration;
 /// <param name="MapExtensionClassSuffix">The generated mapping extension class suffix.</param>
 /// <param name="ReferenceHandling">Indicates whether to use reference handling.</param>
 /// <param name="CopyPrimitiveArrays">Indicates whether to copy object and primitive type arrays into a new array.</param>
+/// <param name="NullHandling">Indicates how to handle null properties.</param>
 internal readonly record struct CodeGeneratorOptions(
     string MapMethodPrefix = "MapTo",
     string MapExtensionClassSuffix = "MapToExtensions",
     ReferenceHandling ReferenceHandling = ReferenceHandling.Disabled,
-    bool CopyPrimitiveArrays = false)
+    bool CopyPrimitiveArrays = false,
+    NullHandling NullHandling = NullHandling.Auto)
 {
     /// <summary>
     /// The prefix of the property name in the .editorconfig file.
@@ -33,6 +35,7 @@ internal readonly record struct CodeGeneratorOptions(
             MapMethodPrefix: provider.GlobalOptions.GetOption(nameof(MapMethodPrefix), "MapTo"),
             MapExtensionClassSuffix: provider.GlobalOptions.GetOption(nameof(MapExtensionClassSuffix), "MapToExtensions"),
             ReferenceHandling: provider.GlobalOptions.GetOption<ReferenceHandling>(nameof(ReferenceHandling)),
-            CopyPrimitiveArrays: provider.GlobalOptions.GetOption(nameof(CopyPrimitiveArrays), false));
+            CopyPrimitiveArrays: provider.GlobalOptions.GetOption(nameof(CopyPrimitiveArrays), false),
+            NullHandling: provider.GlobalOptions.GetOption<NullHandling>(nameof(NullHandling)));
     }
 }

--- a/src/MapTo/Configuration/CompilerOptions.cs
+++ b/src/MapTo/Configuration/CompilerOptions.cs
@@ -6,10 +6,12 @@
 /// <param name="NullableReferenceTypes">Whether to support nullable reference types.</param>
 /// <param name="NullableStaticAnalysis">Whether to support nullable static analysis attributes.</param>
 /// <param name="FileScopedNamespace">Whether to support file-scoped namespace.</param>
+/// <param name="LanguageVersion">The C# language version.</param>
 internal readonly record struct CompilerOptions(
     bool NullableReferenceTypes = true,
     bool NullableStaticAnalysis = true,
-    bool FileScopedNamespace = true)
+    bool FileScopedNamespace = true,
+    LanguageVersion LanguageVersion = LanguageVersion.Latest)
 {
     /// <summary>
     /// Gets the nullable reference syntax. Returns <c>?</c> if <see cref="NullableReferenceTypes" /> is <c>true</c>,

--- a/src/MapTo/Generators/CodeGenerator.cs
+++ b/src/MapTo/Generators/CodeGenerator.cs
@@ -13,7 +13,7 @@ internal readonly record struct CodeGenerator(
 
     public string Build()
     {
-        var writer = new CodeWriter();
+        var writer = new CodeWriter(CompilerOptions);
         var generators = new ICodeGenerator[]
         {
             new FileGenerator(CompilerOptions.NullableReferenceTypes, CompilerOptions.FileScopedNamespace, Mapping),

--- a/src/MapTo/Generators/CodeWriter.cs
+++ b/src/MapTo/Generators/CodeWriter.cs
@@ -1,4 +1,5 @@
 ﻿using System.CodeDom.Compiler;
+using MapTo.Configuration;
 
 namespace MapTo.Generators;
 
@@ -7,13 +8,16 @@ internal sealed class CodeWriter : IDisposable
     private readonly IndentedTextWriter _indentedWriter;
     private readonly StringWriter _writer;
 
-    public CodeWriter()
+    public CodeWriter(CompilerOptions compilerOptions = default)
     {
         _writer = new StringWriter();
+        LanguageVersion = compilerOptions.LanguageVersion;
         _indentedWriter = new IndentedTextWriter(_writer, new string(' ', 4));
     }
 
     public int CurrentIndent => _indentedWriter.Indent;
+
+    public LanguageVersion LanguageVersion { get; }
 
     public string NewLine => _indentedWriter.NewLine;
 
@@ -40,6 +44,12 @@ internal sealed class CodeWriter : IDisposable
     }
 
     public CodeWriter Write(string? value = null)
+    {
+        _indentedWriter.Write(value);
+        return this;
+    }
+
+    public CodeWriter Write(char value)
     {
         _indentedWriter.Write(value);
         return this;
@@ -95,7 +105,7 @@ internal sealed class CodeWriter : IDisposable
         return this;
     }
 
-    public CodeWriter WriteNewLine()
+    public CodeWriter WriteLineIndented()
     {
         _indentedWriter.WriteLine();
         return this;
@@ -175,6 +185,12 @@ internal sealed class CodeWriter : IDisposable
             WriteLines(values);
         }
 
+        return this;
+    }
+
+    public CodeWriter WriteNewLine()
+    {
+        _indentedWriter.WriteLine();
         return this;
     }
 

--- a/src/MapTo/Generators/Handlers/ArrayPropertyMappingGenerator.cs
+++ b/src/MapTo/Generators/Handlers/ArrayPropertyMappingGenerator.cs
@@ -1,0 +1,179 @@
+﻿using MapTo.Mappings;
+using static MapTo.NullHandling;
+using static Microsoft.CodeAnalysis.NullableAnnotation;
+
+namespace MapTo.Generators.Handlers;
+
+internal sealed class ArrayPropertyMappingGenerator : PropertyMappingGenerator
+{
+    /// <inheritdoc />
+    protected override bool HandleCore(PropertyGeneratorContext context)
+    {
+        var (writer, property, parameterName, targetInstanceName, copyPrimitiveArrays, refHandler) = context;
+        if (property is { TypeConverter: not { Type.EnumerableType: EnumerableType.Array } } || targetInstanceName is null)
+        {
+            return false;
+        }
+
+        parameterName = $"{parameterName}.{property.SourceName}";
+
+        if (property.SourceType.IsArray)
+        {
+            MapArray(writer, property, parameterName, targetInstanceName, copyPrimitiveArrays, refHandler);
+        }
+        else
+        {
+            SelectArray(writer, property, parameterName, targetInstanceName, refHandler);
+        }
+
+        return true;
+    }
+
+    private static void MapArray(CodeWriter writer, PropertyMapping property, string parameterName, string targetInstanceName, bool copyPrimitiveArrays, string? refHandler)
+    {
+        switch (property)
+        {
+            case { NullHandling: ThrowException, SourceType.IsNullable: true, TypeConverter.IsMapToExtensionMethod: false } when !copyPrimitiveArrays:
+                writer.Write($"{targetInstanceName}.{property.Name} = ")
+                    .Wrap(Map(writer, property, parameterName, copyPrimitiveArrays, refHandler))
+                    .Write(" ?? ").WriteThrowArgumentNullException(parameterName).WriteLine(";");
+
+                break;
+
+            case { NullHandling: ThrowException }:
+                writer.Write($"{targetInstanceName}.{property.Name} = ")
+                    .WriteIsNullCheck(parameterName).Write(" ? ").WriteThrowArgumentNullException(parameterName)
+                    .Write(" : ").Wrap(Map(writer, property, parameterName, copyPrimitiveArrays, refHandler)).WriteLine(";");
+
+                break;
+
+            case { NullHandling: SetEmptyCollection, SourceType.IsNullable: true, TypeConverter.IsMapToExtensionMethod: false } when !copyPrimitiveArrays:
+                writer.Write($"{targetInstanceName}.{property.Name} = ")
+                    .Wrap(Map(writer, property, parameterName, copyPrimitiveArrays, refHandler))
+                    .Write(" ?? ").Write(property.TypeConverter.Type.EmptySourceCodeString()).WriteLine(";");
+
+                break;
+
+            case { NullHandling: SetEmptyCollection }:
+                writer.Write($"{targetInstanceName}.{property.Name} = ")
+                    .WriteIsNullCheck(parameterName).Write(" ? ").Write(property.TypeConverter.Type.EmptySourceCodeString())
+                    .Write(" : ").Wrap(Map(writer, property, parameterName, copyPrimitiveArrays, refHandler)).WriteLine(";");
+
+                break;
+
+            case { NullHandling: SetNull, SourceType.IsNullable: true }:
+                writer.Write("if (").WriteIsNotNullCheck(parameterName).WriteLine(")")
+                    .WriteOpeningBracket()
+                    .Write($"{targetInstanceName}.{property.Name} = ")
+                    .Wrap(Map(writer, property, parameterName, copyPrimitiveArrays, refHandler))
+                    .WriteLine(";")
+                    .WriteClosingBracket();
+
+                break;
+
+            case { NullHandling: Auto, SourceType.NullableAnnotation: not NotAnnotated, TypeConverter.Type.NullableAnnotation: NotAnnotated } when !copyPrimitiveArrays:
+                writer.Write($"{targetInstanceName}.{property.Name} = ")
+                    .Wrap(Map(writer, property, parameterName, copyPrimitiveArrays, refHandler))
+                    .Write(" ?? ").Write(property.TypeConverter.Type.EmptySourceCodeString()).WriteLine(";");
+
+                break;
+
+            case { NullHandling: Auto, SourceType.NullableAnnotation: not NotAnnotated, TypeConverter.Type.NullableAnnotation: NotAnnotated } when copyPrimitiveArrays:
+                writer.Write($"{targetInstanceName}.{property.Name} = ")
+                    .WriteIsNullCheck(parameterName).Write(" ? ").Write(property.TypeConverter.Type.EmptySourceCodeString())
+                    .Write(" : ").Wrap(Map(writer, property, parameterName, copyPrimitiveArrays, refHandler)).WriteLine(";");
+
+                break;
+
+            case { NullHandling: Auto, SourceType.NullableAnnotation: not NotAnnotated, TypeConverter.Type.NullableAnnotation: Annotated }:
+                writer.Write("if (").WriteIsNotNullCheck(parameterName).WriteLine(")")
+                    .WriteOpeningBracket()
+                    .Write($"{targetInstanceName}.{property.Name} = ")
+                    .Wrap(Map(writer, property, parameterName, copyPrimitiveArrays, refHandler))
+                    .WriteLine(";")
+                    .WriteClosingBracket();
+
+                break;
+
+            default:
+                writer.Write($"{targetInstanceName}.{property.Name} = ").Wrap(Map(writer, property, parameterName, copyPrimitiveArrays, refHandler)).WriteLine(";");
+                break;
+        }
+
+        return;
+
+        static CodeWriter Map(CodeWriter writer, PropertyMapping property, string parameterName, bool copyPrimitiveArrays, string? refHandler)
+        {
+            return property.TypeConverter switch
+            {
+                { IsMapToExtensionMethod: false } when !copyPrimitiveArrays => writer.Write(parameterName),
+                { IsMapToExtensionMethod: true, ReferenceHandling: true } => writer
+                    .Write(property.TypeConverter.MethodName).Write("Array").WriteOpenParenthesis()
+                    .Write(parameterName).Write(", ").Write(refHandler).WriteClosingParenthesis(),
+                _ => writer.Write(property.TypeConverter.MethodName).Write("Array").WriteOpenParenthesis().Write(parameterName).WriteClosingParenthesis()
+            };
+        }
+    }
+
+    private static void SelectArray(CodeWriter writer, PropertyMapping property, string parameterName, string targetInstanceName, string? refHandler)
+    {
+        switch (property.NullHandling)
+        {
+            case ThrowException when property.SourceType.IsNullable:
+                writer.Write($"{targetInstanceName}.{property.Name} = ")
+                    .Wrap(Map(writer, property, parameterName, refHandler))
+                    .Write(" ?? ").WriteThrowArgumentNullException(parameterName);
+
+                break;
+
+            case SetEmptyCollection when property.SourceType.IsNullable:
+                writer.Write($"{targetInstanceName}.{property.Name} = ")
+                    .Wrap(Map(writer, property, parameterName, refHandler))
+                    .Write(" ?? ").Write(property.TypeConverter.Type.EmptySourceCodeString());
+
+                break;
+
+            case SetNull when property.SourceType.IsNullable:
+                writer.Write("if (").WriteIsNotNullCheck(parameterName).WriteLine(")")
+                    .WriteOpeningBracket()
+                    .Write($"{targetInstanceName}.{property.Name} = ")
+                    .Wrap(Map(writer, property, parameterName, refHandler))
+                    .WriteLine(";")
+                    .WriteClosingBracket();
+
+                break;
+
+            case Auto:
+            default:
+                writer.Write($"{targetInstanceName}.{property.Name} = ").Wrap(Map(writer, property, parameterName, refHandler)).Write(";");
+                break;
+        }
+
+        return;
+
+        static CodeWriter Map(CodeWriter writer, PropertyMapping property, string parameterName, string? refHandler)
+        {
+            var p = property.ParameterName[0];
+            var converterMethod = property.TypeConverter.MethodFullName;
+            var linqMethod = property.TypeConverter.Type.EnumerableType.ToLinqSourceCodeString();
+            var parameter = property switch
+            {
+                { NullHandling: SetNull } => parameterName,
+                { NullHandling: Auto, SourceType.NullableAnnotation: NotAnnotated } => parameterName,
+                { SourceType.IsNullable: true } => $"{parameterName}?",
+                _ => parameterName
+            };
+
+            return property.TypeConverter switch
+            {
+                { HasParameter: true } => writer
+                    .Write(parameter).Write(".Select(").Write(p).Write(" => ")
+                    .Write(converterMethod).Write("(").Write(p).Write(")).").Write(linqMethod),
+                { ReferenceHandling: true } => writer
+                    .Write(parameter).Write(".Select(").Write(p).Write(" => ")
+                    .Write(converterMethod).Write("(").Write(p).Write(", ").Write(refHandler).Write(")).").Write(linqMethod),
+                _ => writer.Write(parameter).Write(".Select(").Write(converterMethod).Write(").").Write(linqMethod)
+            };
+        }
+    }
+}

--- a/src/MapTo/Generators/Handlers/GenericEnumerablePropertyMappingGenerator.cs
+++ b/src/MapTo/Generators/Handlers/GenericEnumerablePropertyMappingGenerator.cs
@@ -1,0 +1,84 @@
+﻿using MapTo.Mappings;
+using static MapTo.NullHandling;
+using static Microsoft.CodeAnalysis.NullableAnnotation;
+
+namespace MapTo.Generators.Handlers;
+
+internal sealed class GenericEnumerablePropertyMappingGenerator : PropertyMappingGenerator
+{
+    /// <inheritdoc />
+    protected override bool HandleCore(PropertyGeneratorContext context)
+    {
+        var (writer, property, parameter, targetInstanceName, _, refHandler) = context;
+        if (property.TypeConverter is { Type.EnumerableType: EnumerableType.Array or EnumerableType.None } || targetInstanceName is null)
+        {
+            return false;
+        }
+
+        parameter = $"{parameter}.{property.SourceName}";
+        var parameterName = property switch
+        {
+            { NullHandling: SetNull } => parameter,
+            { NullHandling: Auto, SourceType.NullableAnnotation: NotAnnotated } => parameter,
+            { SourceType.IsNullable: true } => $"{parameter}?",
+            _ => parameter
+        };
+
+        switch (property)
+        {
+            case { NullHandling: ThrowException, SourceType.IsNullable: true }:
+                writer.Write($"{targetInstanceName}.{property.Name} = ")
+                    .Wrap(Map(writer, property, parameterName, refHandler))
+                    .Write($" ?? throw new global::{KnownTypes.ArgumentNullException}(nameof({parameter}));");
+
+                break;
+
+            case { NullHandling: SetEmptyCollection, SourceType.IsNullable: true }:
+                writer.Write($"{targetInstanceName}.{property.Name} = ")
+                    .Wrap(Map(writer, property, parameterName, refHandler))
+                    .Write($" ?? {property.TypeConverter.Type.EmptySourceCodeString()};");
+
+                break;
+
+            case { NullHandling: SetNull, SourceType.IsNullable: true }:
+                writer.Write("if (").WriteIsNotNullCheck(parameter).WriteLine(")")
+                    .WriteOpeningBracket()
+                    .Write($"{targetInstanceName}.{property.Name} = ")
+                    .Wrap(Map(writer, property, parameterName, refHandler))
+                    .WriteLine(";")
+                    .WriteClosingBracket();
+
+                break;
+
+            case { NullHandling: Auto, SourceType.NullableAnnotation: not NotAnnotated, TypeConverter.Type.NullableAnnotation: NotAnnotated }:
+                writer.Write($"{targetInstanceName}.{property.Name} = ")
+                    .Wrap(Map(writer, property, parameterName, refHandler))
+                    .Write($" ?? {property.TypeConverter.Type.EmptySourceCodeString()};");
+
+                break;
+
+            default:
+                writer.Write($"{targetInstanceName}.{property.Name} = ").Wrap(Map(writer, property, parameterName, refHandler)).Write(";");
+                break;
+        }
+
+        return true;
+    }
+
+    private static CodeWriter Map(CodeWriter writer, PropertyMapping property, string parameterName, string? refHandler)
+    {
+        var p = property.ParameterName[0];
+        var converterMethod = property.TypeConverter.MethodFullName;
+        var linqMethod = property.TypeConverter.Type.EnumerableType.ToLinqSourceCodeString();
+
+        return property switch
+        {
+            { TypeConverter.HasParameter: true } =>
+                writer.Write(parameterName).Write(".Select(").Write(p).Write(" => ").Write(converterMethod).Write("(").Write(p).Write(")).").Write(linqMethod),
+            { TypeConverter.ReferenceHandling: true } => writer
+                .Write(parameterName).Write(".Select(").Write(p).Write(" => ")
+                .Write(converterMethod).Write("(").Write(p).Write(", ").Write(refHandler).Write(")).").Write(linqMethod),
+            _ => writer.Write(parameterName).Write($".Select<{property.SourceType.ElementTypeName}, {property.Type.ElementTypeName}>({converterMethod}).{linqMethod}"),
+        };
+    }
+}

--- a/src/MapTo/Generators/Handlers/IPropertyMappingGenerator.cs
+++ b/src/MapTo/Generators/Handlers/IPropertyMappingGenerator.cs
@@ -1,0 +1,8 @@
+﻿namespace MapTo.Generators.Handlers;
+
+internal interface IPropertyMappingGenerator
+{
+    IPropertyMappingGenerator Next(IPropertyMappingGenerator generator);
+
+    bool Handle(PropertyGeneratorContext context);
+}

--- a/src/MapTo/Generators/Handlers/PropertyMappingGenerator.cs
+++ b/src/MapTo/Generators/Handlers/PropertyMappingGenerator.cs
@@ -1,0 +1,17 @@
+﻿namespace MapTo.Generators.Handlers;
+
+internal abstract class PropertyMappingGenerator : IPropertyMappingGenerator
+{
+    private IPropertyMappingGenerator? _next;
+
+    public IPropertyMappingGenerator Next(IPropertyMappingGenerator generator)
+    {
+        _next = generator;
+        return generator;
+    }
+
+    public bool Handle(PropertyGeneratorContext context) =>
+        HandleCore(context) || _next?.Handle(context) == true;
+
+    protected abstract bool HandleCore(PropertyGeneratorContext context);
+}

--- a/src/MapTo/Generators/Handlers/SimplePropertyMappingGenerator.cs
+++ b/src/MapTo/Generators/Handlers/SimplePropertyMappingGenerator.cs
@@ -1,0 +1,41 @@
+﻿using MapTo.Mappings;
+using static MapTo.NullHandling;
+using static Microsoft.CodeAnalysis.NullableAnnotation;
+
+namespace MapTo.Generators.Handlers;
+
+internal sealed class SimplePropertyMappingGenerator : PropertyMappingGenerator
+{
+    /// <inheritdoc />
+    protected override bool HandleCore(PropertyGeneratorContext context)
+    {
+        var (writer, property, parameterName, targetInstanceName, _, _) = context;
+        if (property.HasTypeConverter)
+        {
+            return false;
+        }
+
+        if (targetInstanceName is not null)
+        {
+            writer.Write(targetInstanceName).Write(".").Write(property.Name).Write(" = ");
+        }
+
+        parameterName = $"{parameterName}.{property.SourceName}";
+        writer = property switch
+        {
+            { SourceType.IsNullable: false } => writer.Write(parameterName),
+            { NullHandling: ThrowException } => writer.Write(parameterName).Write(" ?? ").WriteThrowArgumentNullException(parameterName),
+            { NullHandling: SetEmptyCollection } => writer.Write(parameterName).Write(" ?? ").Write(property.Type.EmptySourceCodeString()),
+            { NullHandling: Auto, Type.NullableAnnotation: NotAnnotated, SourceType: { IsNullable: true, NullableAnnotation: not NotAnnotated } } => writer
+                .Write(parameterName).Write(" ?? ").Write(property.Type.EmptySourceCodeString()),
+            _ => writer.Write(parameterName)
+        };
+
+        if (targetInstanceName is not null)
+        {
+            writer.WriteLine(";");
+        }
+
+        return true;
+    }
+}

--- a/src/MapTo/Generators/Handlers/TypeConverterPropertyMappingGenerator.cs
+++ b/src/MapTo/Generators/Handlers/TypeConverterPropertyMappingGenerator.cs
@@ -1,0 +1,63 @@
+﻿using MapTo.Mappings;
+
+namespace MapTo.Generators.Handlers;
+
+internal sealed class TypeConverterPropertyMappingGenerator : PropertyMappingGenerator
+{
+    /// <inheritdoc />
+    protected override bool HandleCore(PropertyGeneratorContext context)
+    {
+        var (writer, property, parameterName, targetInstanceName, _, referenceHandlerName) = context;
+        if (!property.HasTypeConverter)
+        {
+            return false;
+        }
+
+        parameterName = $"{parameterName}.{property.SourceName}";
+
+        switch (property)
+        {
+            case var _ when targetInstanceName is null:
+                Map(writer, property, parameterName, referenceHandlerName);
+                break;
+
+            case { NullHandling: NullHandling.ThrowException }:
+                writer.Write(targetInstanceName).Write(".").Write(property.Name).Write(" = ").WriteIsNullCheck(parameterName)
+                    .Write("?").WriteThrowArgumentNullException(parameterName)
+                    .Write(":").Wrap(Map(writer, property, parameterName, referenceHandlerName)).WriteLine(";");
+
+                break;
+
+            case { NullHandling: NullHandling.SetNull }:
+            case { NullHandling: NullHandling.Auto, SourceType.NullableAnnotation: not NullableAnnotation.NotAnnotated }:
+                writer.Write("if (").WriteIsNotNullCheck(parameterName).WriteLine(")")
+                    .WriteOpeningBracket()
+                    .Write(targetInstanceName).Write(".").Write(property.Name).Write(" = ").Wrap(Map(writer, property, parameterName, referenceHandlerName))
+                    .WriteLine(";")
+                    .WriteClosingBracket();
+
+                break;
+
+            default:
+                writer.Write(targetInstanceName).Write(".").Write(property.Name).Write(" = ").Wrap(Map(writer, property, parameterName, referenceHandlerName)).WriteLine(";");
+                break;
+        }
+
+        return true;
+    }
+
+    private static CodeWriter Map(CodeWriter writer, PropertyMapping property, string parameterName, string? referenceHandlerName)
+    {
+        var typeConverter = property.TypeConverter;
+
+        return typeConverter switch
+        {
+            { HasParameter: true } => writer
+                .Write(typeConverter.MethodFullName).WriteOpenParenthesis().Write(parameterName).Write(", ").Write(typeConverter.Parameter).WriteClosingParenthesis(),
+            { HasParameter: false, ReferenceHandling: false } => writer
+                .Write(typeConverter.MethodFullName).WriteOpenParenthesis().Write(parameterName).WriteClosingParenthesis(),
+            { HasParameter: false, ReferenceHandling: true } => writer
+                .Write(typeConverter.MethodFullName).WriteOpenParenthesis().Write(parameterName).Write(", ").Write(referenceHandlerName).WriteClosingParenthesis()
+        };
+    }
+}

--- a/src/MapTo/Generators/PropertyGenerator.cs
+++ b/src/MapTo/Generators/PropertyGenerator.cs
@@ -1,0 +1,31 @@
+﻿using MapTo.Generators.Handlers;
+
+namespace MapTo.Generators;
+
+internal sealed class PropertyGenerator
+{
+    private static readonly Lazy<PropertyGenerator> LazyInstance = new(() => new PropertyGenerator());
+    private readonly IPropertyMappingGenerator _root;
+
+    private PropertyGenerator()
+    {
+        // The order of the property mapping generators is important
+        // and should be from most specific to least specific.
+        _root = new ArrayPropertyMappingGenerator();
+        _root.Next(new GenericEnumerablePropertyMappingGenerator())
+            .Next(new TypeConverterPropertyMappingGenerator())
+            .Next(new SimplePropertyMappingGenerator());
+    }
+
+    internal static PropertyGenerator Instance => LazyInstance.Value;
+
+    internal void Generate(PropertyGeneratorContext context)
+    {
+        if (!_root.Handle(context))
+        {
+            throw new InvalidOperationException(
+                $"Unable to find a property mapping generator for the {context.PropertyMapping.TypeName}.{context.PropertyMapping.Name}." +
+                $"Please open an issue at https://github.com/mrtaikandi/mapto");
+        }
+    }
+}

--- a/src/MapTo/Generators/PropertyGeneratorContext.cs
+++ b/src/MapTo/Generators/PropertyGeneratorContext.cs
@@ -1,0 +1,11 @@
+﻿using MapTo.Mappings;
+
+namespace MapTo.Generators;
+
+internal readonly record struct PropertyGeneratorContext(
+    CodeWriter Writer,
+    PropertyMapping PropertyMapping,
+    string ContainingSourceTypeParameterName,
+    string? TargetInstanceName,
+    bool CopyPrimitiveArrays,
+    string? ReferenceHandlerName);

--- a/src/MapTo/KnownTypes.cs
+++ b/src/MapTo/KnownTypes.cs
@@ -10,6 +10,10 @@ internal record KnownTypes(
 {
     internal const string NotNullIfNotNullAttributeFullName = "System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute";
     internal const string CompilerGeneratedAttributeFullName = "System.Runtime.CompilerServices.CompilerGeneratedAttribute";
+    internal const string ArgumentNullException = "System.ArgumentNullException";
+    internal const string GenericList = "System.Collections.Generic.List";
+    internal const string Array = "System.Array";
+    internal const string LinqEnumerable = "System.Linq.Enumerable";
 
     internal static KnownTypes Create(Compilation compilation) => new(
         MapFromAttributeTypeSymbol: compilation.GetTypeByMetadataNameOrThrow<MapFromAttribute>(),

--- a/src/MapTo/MapTo.props
+++ b/src/MapTo/MapTo.props
@@ -4,5 +4,6 @@
         <CompilerVisibleProperty Include="MapTo_MapExtensionClassSuffix"/>
         <CompilerVisibleProperty Include="MapTo_ReferenceHandling"/>
         <CompilerVisibleProperty Include="MapTo_CopyPrimitiveArrays"/>
+        <CompilerVisibleProperty Include="MapTo_NullHandling"/>
     </ItemGroup>
 </Project>

--- a/src/MapTo/Mappings/EnumerableType.cs
+++ b/src/MapTo/Mappings/EnumerableType.cs
@@ -1,0 +1,23 @@
+﻿namespace MapTo.Mappings;
+
+internal enum EnumerableType
+{
+    None,
+    Array,
+    List,
+    Enumerable,
+    ReadOnlyCollection
+}
+
+[SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1649:File name should match first type name", Justification = "Reviewed.")]
+internal static class EnumerableTypeExtensions
+{
+    internal static string ToLinqSourceCodeString(this EnumerableType enumerableType) => enumerableType switch
+    {
+        EnumerableType.Array => "ToArray()",
+        EnumerableType.List => "ToList()",
+        EnumerableType.Enumerable => "ToArray()",
+        EnumerableType.ReadOnlyCollection => "ToArray()",
+        _ => "ToList()"
+    };
+}

--- a/src/MapTo/Mappings/TypeConverterMapping.cs
+++ b/src/MapTo/Mappings/TypeConverterMapping.cs
@@ -6,7 +6,9 @@ internal enum EnumerableType
 {
     None,
     Array,
-    List
+    List,
+    Enumerable,
+    ReadOnlyCollection
 }
 
 internal readonly record struct TypeConverterMapping(

--- a/src/MapTo/Mappings/TypeConverterMapping.cs
+++ b/src/MapTo/Mappings/TypeConverterMapping.cs
@@ -2,33 +2,24 @@
 
 namespace MapTo.Mappings;
 
-internal enum EnumerableType
-{
-    None,
-    Array,
-    List,
-    Enumerable,
-    ReadOnlyCollection
-}
-
 internal readonly record struct TypeConverterMapping(
     string ContainingType,
     string MethodName,
     string? Parameter,
-    string? EnumerableElementTypeName = null,
-    EnumerableType EnumerableType = EnumerableType.None,
+    TypeMapping Type,
     bool IsMapToExtensionMethod = false,
     bool ReferenceHandling = false,
     ImmutableArray<string>? UsingDirectives = null)
 {
     public TypeConverterMapping(IMethodSymbol method, TypedConstant? parameters)
-        : this(method.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat), method.Name, parameters?.ToSourceCodeString()) { }
+        : this(
+            ContainingType: method.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+            MethodName: method.Name,
+            Parameter: parameters?.ToSourceCodeString(),
+            Type: method.ReturnType.ToTypeMapping()) { }
 
     [MemberNotNullWhen(true, nameof(Parameter))]
     public bool HasParameter => Parameter is not null;
-
-    [MemberNotNullWhen(true, nameof(EnumerableElementTypeName))]
-    public bool IsEnumerable => EnumerableElementTypeName is not null;
 
     public string MethodFullName => $"{ContainingType}.{MethodName}";
 }

--- a/src/MapTo/Mappings/TypeMapping.cs
+++ b/src/MapTo/Mappings/TypeMapping.cs
@@ -3,11 +3,40 @@
 namespace MapTo.Mappings;
 
 [DebuggerDisplay($"FQN: {{{nameof(FullName)}}}")]
-internal readonly record struct TypeMapping(string Name, string FullName);
+internal readonly record struct TypeMapping(
+    string Name,
+    string FullName,
+    bool IsArray,
+    string ElementTypeFullName)
+{
+#if DEBUG
+    internal ITypeSymbol OriginalTypeSymbol { get; init; }
+#endif
+}
 
 internal static class TypeMappingExtensions
 {
-    internal static TypeMapping ToTypeMapping(this ITypeSymbol typeSymbol) => new(
-        Name: typeSymbol.Name,
-        FullName: typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+    internal static TypeMapping ToTypeMapping(this ITypeSymbol typeSymbol)
+    {
+        var isArray = false;
+        var elementType = string.Empty;
+
+        if (typeSymbol is IArrayTypeSymbol arrayTypeSymbol)
+        {
+            isArray = true;
+            elementType = arrayTypeSymbol.ElementType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        }
+
+        var mapping = new TypeMapping(
+            Name: typeSymbol.Name,
+            FullName: typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+            IsArray: isArray,
+            ElementTypeFullName: elementType);
+
+#if DEBUG
+        return mapping with { OriginalTypeSymbol = typeSymbol };
+#else
+        return mapping;
+#endif
+    }
 }

--- a/stylecop.ruleset
+++ b/stylecop.ruleset
@@ -55,7 +55,7 @@
         <Rule Id="SA1115"  Action="Warning" />          <!-- Parameter should follow comma -->
         <Rule Id="SA1116"  Action="Warning" />          <!-- Split parameters should start on line after declaration -->
         <Rule Id="SA1117"  Action="Warning" />          <!-- Parameters should be on same line or separate lines -->
-        <Rule Id="SA1118"  Action="Warning" />          <!-- Parameter should not span multiple lines -->
+        <Rule Id="SA1118"  Action="None" />          <!-- Parameter should not span multiple lines -->
         <Rule Id="SA1120"  Action="Warning" />          <!-- Comments should contain text -->
         <Rule Id="SA1121"  Action="Warning" />          <!-- Use built-in type alias -->
         <Rule Id="SA1122"  Action="Warning" />          <!-- Use string.Empty for empty strings -->

--- a/test/MapTo.Tests/ConstructorMappingTests.cs
+++ b/test/MapTo.Tests/ConstructorMappingTests.cs
@@ -223,7 +223,6 @@ public class ConstructorMappingTests
         var (compilation, diagnostics) = builder.Compile();
 
         // Assert
-        compilation.Dump(_output);
         diagnostics.ShouldBeSuccessful();
 
         compilation

--- a/test/MapTo.Tests/ConstructorMappingTests.cs
+++ b/test/MapTo.Tests/ConstructorMappingTests.cs
@@ -15,7 +15,7 @@ public class ConstructorMappingTests
     public void When_TargetWithReadOnlyPropertyAndConstructor_Should_NotGenerateConstructorAndUseConstructorInitializer()
     {
         // Arrange
-        var builder = new TestSourceBuilder();
+        var builder = new TestSourceBuilder(TestSourceBuilderOptions.Create(supportNullReferenceTypes: false));
         var sourceFile = builder.AddFile();
         sourceFile.AddClass(Accessibility.Public, "SourceClass").WithProperty<int>("Id").WithProperty<string>("Name");
         sourceFile.AddClass(Accessibility.Public, "TargetClass", true, attributes: "[MapFrom(typeof(SourceClass))]")
@@ -46,7 +46,7 @@ public class ConstructorMappingTests
     public void When_TargetWithReadOnlyPropertyAndNoConstructors_Should_GenerateConstructor()
     {
         // Arrange
-        var builder = new TestSourceBuilder();
+        var builder = new TestSourceBuilder(TestSourceBuilderOptions.Create(supportNullReferenceTypes: false));
         var sourceFile = builder.AddFile();
         sourceFile.AddClass(Accessibility.Public, "SourceClass").WithProperty<int>("Id").WithProperty<string>("Name");
         sourceFile.AddClass(Accessibility.Public, "TargetClass", true, attributes: "[MapFrom(typeof(SourceClass))]")
@@ -94,7 +94,7 @@ public class ConstructorMappingTests
     public void When_TargetHasMultipleConstructorsWithSameParameterCount_Should_ChooseAnyOfThem()
     {
         // Arrange
-        var builder = new TestSourceBuilder();
+        var builder = new TestSourceBuilder(TestSourceBuilderOptions.Create(supportNullReferenceTypes: false));
         var sourceFile = builder.AddFile();
 
         sourceFile.AddClass(Accessibility.Public, "SourceClass").WithProperty<int>("Id").WithProperty<string>("Name");
@@ -118,7 +118,7 @@ public class ConstructorMappingTests
     public void When_TargetHasMultipleConstructorsWithoutMapConstructorAttribute_Should_ChooseTheOneWithMostParameters()
     {
         // Arrange
-        var builder = new TestSourceBuilder();
+        var builder = new TestSourceBuilder(TestSourceBuilderOptions.Create(supportNullReferenceTypes: false));
         var sourceFile = builder.AddFile();
 
         sourceFile.AddClass(Accessibility.Public, "SourceClass").WithProperty<int>("Id").WithProperty<string>("Name").WithProperty<int>("Prop");
@@ -154,12 +154,12 @@ public class ConstructorMappingTests
     {
         // Arrange
         var builder = new TestSourceBuilder();
-        var sourceFile = builder.AddFile();
+        var sourceFile = builder.AddFile(supportNullableReferenceTypes: true);
 
-        sourceFile.AddClass(Accessibility.Public, "SourceClass").WithProperty<int>("Id").WithProperty<string>("Name");
+        sourceFile.AddClass(Accessibility.Public, "SourceClass").WithProperty<int>("Id").WithProperty<string>("Name", defaultValue: "string.Empty");
         sourceFile.AddClass(Accessibility.Public, "TargetClass", true, attributes: "[MapFrom(typeof(SourceClass))]")
             .WithProperty<int?>("Id")
-            .WithProperty<string>("Name")
+            .WithProperty<string>("Name", defaultValue: "string.Empty")
             .WithConstructor("public TargetClass(int id) => Id = id;")
             .WithConstructor("[MapConstructor] public TargetClass(string name) => Name = name;")
             .WithConstructor("public TargetClass(int id, string name) => (Id, Name) = (id, name);");

--- a/test/MapTo.Tests/MapFromTests.cs
+++ b/test/MapTo.Tests/MapFromTests.cs
@@ -81,7 +81,7 @@ public class MapFromTests
     public void When_FoundMappingSource_With_DifferentNamespaces_Should_UseCorrectNamespace()
     {
         // Arrange
-        var builder = ScenarioBuilder.SimpleMappedClassInDifferentNamespaceAsSource();
+        var builder = ScenarioBuilder.SimpleMappedClassInDifferentNamespaceAsSource(TestSourceBuilderOptions.Create());
 
         // Act
         var (compilation, diagnostics) = builder.Compile();
@@ -96,7 +96,7 @@ public class MapFromTests
                             [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("sourceClass")]
                             public static global::ExternalLibMap.TargetClass? MapToTargetClass(this global::ExternalLib.SourceClass? sourceClass)
                             {
-                                if (ReferenceEquals(sourceClass, null))
+                                if (sourceClass is null)
                                 {
                                     return null;
                                 }
@@ -127,7 +127,7 @@ public class MapFromTests
     public void When_FoundMappingSource_WithReadOnlyPropertyNames_Should_UseGenerateAndUseConstructorInitializer()
     {
         // Arrange
-        var builder = new TestSourceBuilder();
+        var builder = new TestSourceBuilder(TestSourceBuilderOptions.Create());
         var sourceFile = builder.AddFile();
         sourceFile.AddClass(Accessibility.Public, "SourceClass").WithProperty<int>("Id").WithProperty<string>("Name");
         sourceFile.AddClass(Accessibility.Public, "TargetClass", true, attributes: "[MapFrom(typeof(SourceClass))]")
@@ -147,7 +147,7 @@ public class MapFromTests
                             [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("sourceClass")]
                             public static TargetClass? MapToTargetClass(this SourceClass? sourceClass)
                             {
-                                if (ReferenceEquals(sourceClass, null))
+                                if (sourceClass is null)
                                 {
                                     return null;
                                 }
@@ -248,7 +248,7 @@ public class MapFromTests
                   [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("sourceClass")]
                   public static TargetClass? MapToTargetClass(this SourceClass? sourceClass)
                   {
-                      if (ReferenceEquals(sourceClass, null))
+                      if (sourceClass is null)
                       {
                           return null;
                       }

--- a/test/MapTo.Tests/MapFromTests.cs
+++ b/test/MapTo.Tests/MapFromTests.cs
@@ -404,7 +404,6 @@ public class MapFromTests
         var (compilation, diagnostics) = builder.Compile(assertOutputCompilation: false);
 
         // Assert
-        compilation.Dump(_output);
         var sourceTypeSymbol = compilation.GetTypeByMetadataName("MapTo.Tests.SourceClass").ShouldNotBeNull();
 
         var extensionClassDeclaration = compilation.GetClassDeclaration("TargetClass", "TestFile1.g.cs").ShouldNotBeNull();
@@ -433,7 +432,6 @@ public class MapFromTests
         var (compilation, diagnostics) = builder.Compile(assertOutputCompilation: false);
 
         // Assert
-        compilation.Dump(_output);
         var sourceTypeSymbol = compilation.GetTypeByMetadataName("MapTo.Tests.SourceClass").ShouldNotBeNull();
 
         var extensionClassDeclaration = compilation.GetClassDeclaration("TargetClass", "TestFile1.g.cs").ShouldNotBeNull();
@@ -485,7 +483,6 @@ public class MapFromTests
         var (compilation, diagnostics) = builder.Compile();
 
         // Assert
-        compilation.Dump(_output);
         diagnostics.ShouldBeSuccessful();
         compilation.GetClassDeclaration("SourceClassMapToExtensions")
             .ShouldContain("MapTo.Tests.TargetClass.CustomBeforeMapMethod(sourceClass);");
@@ -507,7 +504,6 @@ public class MapFromTests
         var (compilation, diagnostics) = builder.Compile(assertOutputCompilation: false);
 
         // Assert
-        compilation.Dump(_output);
         var sourceTypeSymbol = compilation.GetTypeByMetadataName("MapTo.Tests.SourceClass").ShouldNotBeNull();
 
         var extensionClassDeclaration = compilation.GetClassDeclaration("TargetClass", "TestFile1.g.cs").ShouldNotBeNull();
@@ -732,7 +728,6 @@ public class MapFromTests
         var (compilation, _) = builder.Compile(assertOutputCompilation: false);
 
         // Assert
-        compilation.Dump(_output);
         compilation.GetDiagnostics().ShouldNotBeSuccessful("CS0122", "'TargetClass.CustomAfterMapMethod()' is inaccessible due to its protection level");
     }
 
@@ -778,7 +773,6 @@ public class MapFromTests
         var (compilation, diagnostics) = builder.Compile(assertOutputCompilation: false);
 
         // Assert
-        compilation.Dump(_output);
         var targetTypeSymbol = compilation.GetTypeByMetadataName("MapTo.Tests.TargetClass").ShouldNotBeNull();
 
         var extensionClassDeclaration = compilation.GetClassDeclaration("TargetClass", "TestFile1.g.cs").ShouldNotBeNull();
@@ -807,7 +801,6 @@ public class MapFromTests
         var (compilation, diagnostics) = builder.Compile(assertOutputCompilation: false);
 
         // Assert
-        compilation.Dump(_output);
         var targetTypeSymbol = compilation.GetTypeByMetadataName("MapTo.Tests.TargetClass").ShouldNotBeNull();
 
         var extensionClassDeclaration = compilation.GetClassDeclaration("TargetClass", "TestFile1.g.cs").ShouldNotBeNull();

--- a/test/MapTo.Tests/MapPropertyTests.cs
+++ b/test/MapTo.Tests/MapPropertyTests.cs
@@ -24,7 +24,6 @@ public class MapPropertyTests
         var (compilation, diagnostics) = builder.Compile();
 
         // Assert
-        compilation.Dump(_output);
         diagnostics.ShouldBeSuccessful();
         compilation.GetClassDeclaration("SourceClassMapToExtensions")
             .ShouldContain("""

--- a/test/MapTo.Tests/MapRecordTests.cs
+++ b/test/MapTo.Tests/MapRecordTests.cs
@@ -135,7 +135,6 @@ public class MapRecordTests
         var (compilation, diagnostics) = builder.Compile();
 
         // Assert
-        compilation.Dump(_output);
         diagnostics.ShouldBeSuccessful();
         compilation
             .GetClassDeclaration("SourceRecordMapToExtensions")

--- a/test/MapTo.Tests/MapRecordTests.cs
+++ b/test/MapTo.Tests/MapRecordTests.cs
@@ -100,7 +100,7 @@ public class MapRecordTests
                 [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("sourceRecord")]
                 public static TargetRecord? MapToTargetRecord(this SourceRecord? sourceRecord)
                 {
-                    if (ReferenceEquals(sourceRecord, null))
+                    if (sourceRecord is null)
                     {
                         return null;
                     }

--- a/test/MapTo.Tests/NullHandlingTests.cs
+++ b/test/MapTo.Tests/NullHandlingTests.cs
@@ -1,0 +1,746 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace MapTo.Tests;
+
+public class NullHandlingTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public NullHandlingTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public void When_NullHandlingIsSetNull_Should_CheckIfSourcePropertyIsNull()
+    {
+        // Arrange
+        var builder = ScenarioBuilder.BuildEmployeeManagerModels(TestSourceBuilderOptions.Create(analyzerConfigOptions: new Dictionary<string, string>
+        {
+            [nameof(CodeGeneratorOptions.NullHandling)] = NullHandling.SetNull.ToString()
+        }));
+
+        // Act
+        var (compilation, diagnostics) = builder.Compile();
+
+        // Assert
+        diagnostics.ShouldBeSuccessful();
+
+        var employeeExtensionClass = compilation.GetClassDeclaration("EmployeeMapToExtensions", "MapTo.Tests.EmployeeViewModel.g.cs");
+        employeeExtensionClass.ShouldContain(
+            """
+            if (employee.Manager is not null)
+            {
+                target.Manager = global::MapTo.Tests.ManagerMapToExtensions.MapToManagerViewModel(employee.Manager);
+            }
+            """);
+    }
+
+    [Fact]
+    public void When_NullHandlingIsThrowException_Should_ThrowExceptionIfSourceIsNull()
+    {
+        // Arrange
+        var builder = ScenarioBuilder.BuildEmployeeManagerModels(TestSourceBuilderOptions.Create(analyzerConfigOptions: new Dictionary<string, string>
+        {
+            [nameof(CodeGeneratorOptions.NullHandling)] = NullHandling.ThrowException.ToString()
+        }));
+
+        // Act
+        var (compilation, diagnostics) = builder.Compile();
+
+        // Assert
+        diagnostics.ShouldBeSuccessful();
+
+        var employeeExtensionClass = compilation.GetClassDeclaration("EmployeeMapToExtensions", "MapTo.Tests.EmployeeViewModel.g.cs");
+        employeeExtensionClass.ShouldContain(
+            "target.Manager = employee.Manager is null ? throw new global::System.ArgumentNullException(nameof(employee.Manager)) : global::MapTo.Tests.ManagerMapToExtensions.MapToManagerViewModel(employee.Manager);");
+    }
+
+    [Fact]
+    public void When_NullHandlingIsAutoAndNullabilityContextIsDisabled_Should_CheckIfSourcePropertyIsNull()
+    {
+        // Arrange
+        var builder = ScenarioBuilder.BuildEmployeeManagerModels(TestSourceBuilderOptions.Create(
+            supportNullReferenceTypes: false,
+            analyzerConfigOptions: new Dictionary<string, string>
+            {
+                [nameof(CodeGeneratorOptions.NullHandling)] = NullHandling.Auto.ToString()
+            }));
+
+        // Act
+        var (compilation, diagnostics) = builder.Compile();
+
+        // Assert
+        diagnostics.ShouldBeSuccessful();
+
+        var employeeExtensionClass = compilation.GetClassDeclaration("EmployeeMapToExtensions", "MapTo.Tests.EmployeeViewModel.g.cs");
+        employeeExtensionClass.ShouldContain(
+            """
+            if (employee.Manager is not null)
+            {
+                target.Manager = global::MapTo.Tests.ManagerMapToExtensions.MapToManagerViewModel(employee.Manager);
+            }
+            """);
+    }
+
+    [Fact]
+    public void When_NullHandlingIsAutoAndSourceIsNotAnnotated_Should_CheckIfSourcePropertyIsNull()
+    {
+        // Arrange
+        var builder = ScenarioBuilder.BuildEmployeeManagerModels(TestSourceBuilderOptions.Create(
+            supportNullReferenceTypes: true,
+            analyzerConfigOptions: new Dictionary<string, string>
+            {
+                [nameof(CodeGeneratorOptions.NullHandling)] = NullHandling.Auto.ToString()
+            }));
+
+        // Act
+        var (compilation, diagnostics) = builder.Compile();
+
+        // Assert
+        diagnostics.ShouldBeSuccessful();
+
+        var employeeExtensionClass = compilation.GetClassDeclaration("EmployeeMapToExtensions", "MapTo.Tests.EmployeeViewModel.g.cs");
+        employeeExtensionClass.ShouldContain(
+            """
+            if (employee.Manager is not null)
+            {
+                target.Manager = global::MapTo.Tests.ManagerMapToExtensions.MapToManagerViewModel(employee.Manager);
+            }
+            """);
+    }
+
+    [Fact]
+    public void When_NullHandlingIsAutoAndSourceIsAnnotated_Should_CheckIfSourcePropertyIsNull()
+    {
+        // Arrange
+        var builder = new TestSourceBuilder(
+            supportNullReferenceTypes: true,
+            analyzerConfigOptions: new Dictionary<string, string>
+            {
+                [nameof(CodeGeneratorOptions.NullHandling)] = NullHandling.Auto.ToString()
+            });
+
+        var sourceFile = builder.AddFile(supportNullableReferenceTypes: true);
+        sourceFile.AddClass(Accessibility.Public, "MiddleClass").WithProperty<int>("Key");
+        sourceFile.AddClass(Accessibility.Public, "MappedMiddleClass", attributes: "[MapFrom(typeof(MiddleClass))]")
+            .WithProperty<int>("Key");
+
+        sourceFile.AddClass(Accessibility.Public, "SourceClass").WithProperty("MiddleClass?", "Prop1", defaultValue: "null!");
+        sourceFile.AddClass(Accessibility.Public, "TargetClass", true, attributes: "[MapFrom(typeof(SourceClass))]")
+            .WithProperty("MappedMiddleClass", "Prop1", defaultValue: "null!");
+
+        // Act
+        var (compilation, diagnostics) = builder.Compile();
+
+        // Assert
+        diagnostics.ShouldBeSuccessful();
+
+        var extensionClass = compilation.GetClassDeclaration("SourceClassMapToExtensions").ShouldNotBeNull();
+        extensionClass.ShouldContain(
+            """
+            if (sourceClass.Prop1 is not null)
+            {
+                target.Prop1 = global::MapTo.Tests.MiddleClassMapToExtensions.MapToMappedMiddleClass(sourceClass.Prop1);
+            }
+            """);
+    }
+
+    [Fact]
+    public void When_NullHandlingIsAutoAndSourceIsNotNullable_Should_AssignDirectly()
+    {
+        // Arrange
+        var builder = new TestSourceBuilder(
+            supportNullReferenceTypes: true,
+            analyzerConfigOptions: new Dictionary<string, string>
+            {
+                [nameof(CodeGeneratorOptions.NullHandling)] = NullHandling.Auto.ToString()
+            });
+
+        var sourceFile = builder.AddFile(supportNullableReferenceTypes: true);
+        sourceFile.AddClass(Accessibility.Public, "MiddleClass").WithProperty<int>("Key");
+        sourceFile.AddClass(Accessibility.Public, "MappedMiddleClass", attributes: "[MapFrom(typeof(MiddleClass))]")
+            .WithProperty<int>("Key");
+
+        sourceFile.AddClass(Accessibility.Public, "SourceClass").WithProperty("MiddleClass", "Prop1", defaultValue: "null!");
+        sourceFile.AddClass(Accessibility.Public, "TargetClass", true, attributes: "[MapFrom(typeof(SourceClass))]")
+            .WithProperty("MappedMiddleClass", "Prop1", defaultValue: "null!");
+
+        // Act
+        var (compilation, diagnostics) = builder.Compile();
+
+        // Assert
+        diagnostics.ShouldBeSuccessful();
+
+        var extensionClass = compilation.GetClassDeclaration("SourceClassMapToExtensions").ShouldNotBeNull();
+        extensionClass.ShouldContain("target.Prop1 = global::MapTo.Tests.MiddleClassMapToExtensions.MapToMappedMiddleClass(sourceClass.Prop1);");
+    }
+
+    [Theory]
+    [MemberData(nameof(CollectionNullHandlingAutoTestData))]
+    [MemberData(nameof(CollectionNullHandlingSetNullTestData))]
+    [MemberData(nameof(CollectionNullHandlingThrowExceptionTestData))]
+    [MemberData(nameof(CollectionNullHandlingSetEmptyCollectionTestData))]
+    public void VerifyCollectionNullHandling(
+        int key,
+        bool supportNullableTypes,
+        bool copyPrimitiveArrays,
+        NullHandling nullHandling,
+        string sourceProperty,
+        string targetProperty,
+        string expected)
+    {
+        // Arrange
+        key.ShouldBeGreaterThan(0);
+        var builder = new TestSourceBuilder(
+            supportNullReferenceTypes: supportNullableTypes,
+            analyzerConfigOptions: new Dictionary<string, string>
+            {
+                [nameof(CodeGeneratorOptions.NullHandling)] = nullHandling.ToString(),
+                [nameof(CodeGeneratorOptions.CopyPrimitiveArrays)] = copyPrimitiveArrays.ToString()
+            });
+
+        var sourceFile = builder.AddFile(supportNullableReferenceTypes: supportNullableTypes, usings: new[] { "System.Collections", "System.Collections.Generic" });
+        sourceFile.AddClass(Accessibility.Public, "MiddleClass").WithProperty<int>("Key");
+        sourceFile.AddClass(Accessibility.Public, "MappedMiddleClass", attributes: "[MapFrom(typeof(MiddleClass))]")
+            .WithProperty<int>("Key");
+
+        sourceFile.AddClass(Accessibility.Public, "SourceClass").WithProperty(sourceProperty, "Prop1", defaultValue: "null!");
+        sourceFile.AddClass(Accessibility.Public, "TargetClass", true, attributes: "[MapFrom(typeof(SourceClass))]")
+            .WithProperty(targetProperty, "Prop1", defaultValue: "null!");
+
+        // Act
+        var (compilation, diagnostics) = builder.Compile(assertOutputCompilation: false);
+
+        // Assert
+        compilation.Dump(_output);
+        compilation.ShouldBeSuccessful();
+        diagnostics.ShouldBeSuccessful();
+
+        var extensionClass = compilation.GetClassDeclaration("SourceClassMapToExtensions").ShouldNotBeNull();
+        extensionClass.ShouldContain(expected);
+    }
+
+    [SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1204:Static elements should appear before instance elements", Justification = "Test data")]
+    public static IEnumerable<object[]> CollectionNullHandlingThrowExceptionTestData()
+    {
+        yield return new object[]
+        {
+            1, false, false, NullHandling.ThrowException, "List<int>", "List<int>",
+            "target.Prop1 = sourceClass.Prop1 ?? throw new global::System.ArgumentNullException(nameof(sourceClass.Prop1));"
+        };
+
+        yield return new object[]
+        {
+            2, false, false, NullHandling.ThrowException, "string[]", "string[]",
+            "target.Prop1 = sourceClass.Prop1 ?? throw new global::System.ArgumentNullException(nameof(sourceClass.Prop1));"
+        };
+
+        yield return new object[]
+        {
+            3, false, false, NullHandling.ThrowException, "MiddleClass[]", "MiddleClass[]",
+            "target.Prop1 = sourceClass.Prop1 ?? throw new global::System.ArgumentNullException(nameof(sourceClass.Prop1));"
+        };
+
+        yield return new object[]
+        {
+            4, false, false, NullHandling.ThrowException, "List<MiddleClass>", "List<MappedMiddleClass>",
+            "target.Prop1 = sourceClass.Prop1?.Select<global::MapTo.Tests.MiddleClass, global::MapTo.Tests.MappedMiddleClass>(global::MapTo.Tests.MiddleClassMapToExtensions.MapToMappedMiddleClass).ToList() ?? throw new global::System.ArgumentNullException(nameof(sourceClass.Prop1));"
+        };
+
+        yield return new object[]
+        {
+            5, false, true, NullHandling.ThrowException, "List<int>", "List<int>",
+            "target.Prop1 = sourceClass.Prop1 ?? throw new global::System.ArgumentNullException(nameof(sourceClass.Prop1));"
+        };
+
+        yield return new object[]
+        {
+            6, false, true, NullHandling.ThrowException, "string[]", "string[]",
+            "target.Prop1 = sourceClass.Prop1 is null ? throw new global::System.ArgumentNullException(nameof(sourceClass.Prop1)) : MapToStringArray(sourceClass.Prop1);"
+        };
+
+        yield return new object[]
+        {
+            7, false, true, NullHandling.ThrowException, "MiddleClass[]", "MiddleClass[]",
+            "target.Prop1 = sourceClass.Prop1 is null ? throw new global::System.ArgumentNullException(nameof(sourceClass.Prop1)) : MapToMiddleClassArray(sourceClass.Prop1);"
+        };
+
+        yield return new object[]
+        {
+            8, true, false, NullHandling.ThrowException, "int[]", "int[]",
+            "target.Prop1 = sourceClass.Prop1 ?? throw new global::System.ArgumentNullException(nameof(sourceClass.Prop1));"
+        };
+
+        yield return new object[]
+        {
+            9, true, false, NullHandling.ThrowException, "int[]", "int[]?",
+            "target.Prop1 = sourceClass.Prop1 ?? throw new global::System.ArgumentNullException(nameof(sourceClass.Prop1));"
+        };
+
+        yield return new object[]
+        {
+            10, true, false, NullHandling.ThrowException, "int[]?", "int[]",
+            "target.Prop1 = sourceClass.Prop1 ?? throw new global::System.ArgumentNullException(nameof(sourceClass.Prop1));"
+        };
+
+        yield return new object[]
+        {
+            11, true, false, NullHandling.ThrowException, "string[]", "string?[]",
+            "target.Prop1 = sourceClass.Prop1 ?? throw new global::System.ArgumentNullException(nameof(sourceClass.Prop1));"
+        };
+
+        yield return new object[]
+        {
+            12, true, true, NullHandling.ThrowException, "int[]", "int[]",
+            "target.Prop1 = sourceClass.Prop1 is null ? throw new global::System.ArgumentNullException(nameof(sourceClass.Prop1)) : MapToInt32Array(sourceClass.Prop1);"
+        };
+
+        yield return new object[]
+        {
+            13, true, true, NullHandling.ThrowException, "int[]?", "int[]",
+            "target.Prop1 = sourceClass.Prop1 is null ? throw new global::System.ArgumentNullException(nameof(sourceClass.Prop1)) : MapToInt32Array(sourceClass.Prop1);"
+        };
+
+        yield return new object[]
+        {
+            14, true, true, NullHandling.ThrowException, "int[]", "int[]?",
+            "target.Prop1 = sourceClass.Prop1 is null ? throw new global::System.ArgumentNullException(nameof(sourceClass.Prop1)) : MapToInt32Array(sourceClass.Prop1);"
+        };
+
+        yield return new object[]
+        {
+            15, true, true, NullHandling.ThrowException, "string[]", "string?[]",
+            "target.Prop1 = sourceClass.Prop1 is null ? throw new global::System.ArgumentNullException(nameof(sourceClass.Prop1)) : MapToStringArray(sourceClass.Prop1);"
+        };
+
+        yield return new object[]
+        {
+            16, true, true, NullHandling.ThrowException, "List<MiddleClass>", "List<MappedMiddleClass>?",
+            "target.Prop1 = sourceClass.Prop1?.Select<global::MapTo.Tests.MiddleClass, global::MapTo.Tests.MappedMiddleClass>(global::MapTo.Tests.MiddleClassMapToExtensions.MapToMappedMiddleClass).ToList() ?? throw new global::System.ArgumentNullException(nameof(sourceClass.Prop1));"
+        };
+
+        yield return new object[]
+        {
+            17, true, true, NullHandling.ThrowException, "List<MiddleClass>?", "List<MappedMiddleClass>",
+            "target.Prop1 = sourceClass.Prop1?.Select<global::MapTo.Tests.MiddleClass, global::MapTo.Tests.MappedMiddleClass>(global::MapTo.Tests.MiddleClassMapToExtensions.MapToMappedMiddleClass).ToList() ?? throw new global::System.ArgumentNullException(nameof(sourceClass.Prop1));"
+        };
+
+        yield return new object[]
+        {
+            18, true, true, NullHandling.ThrowException, "List<MiddleClass>?", "List<MappedMiddleClass>?",
+            "target.Prop1 = sourceClass.Prop1?.Select<global::MapTo.Tests.MiddleClass, global::MapTo.Tests.MappedMiddleClass>(global::MapTo.Tests.MiddleClassMapToExtensions.MapToMappedMiddleClass).ToList() ?? throw new global::System.ArgumentNullException(nameof(sourceClass.Prop1));"
+        };
+
+        yield return new object[]
+        {
+            19, true, true, NullHandling.ThrowException, "List<MiddleClass?>", "List<MappedMiddleClass?>",
+            "target.Prop1 = sourceClass.Prop1?.Select<global::MapTo.Tests.MiddleClass?, global::MapTo.Tests.MappedMiddleClass?>(global::MapTo.Tests.MiddleClassMapToExtensions.MapToMappedMiddleClass).ToList() ?? throw new global::System.ArgumentNullException(nameof(sourceClass.Prop1));"
+        };
+    }
+
+    [SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1204:Static elements should appear before instance elements", Justification = "Test data")]
+    public static IEnumerable<object[]> CollectionNullHandlingSetEmptyCollectionTestData()
+    {
+        yield return new object[]
+        {
+            20, false, false, NullHandling.SetEmptyCollection, "List<int>", "List<int>",
+            "target.Prop1 = sourceClass.Prop1 ?? new global::System.Collections.Generic.List<int>();"
+        };
+
+        yield return new object[]
+        {
+            21, false, false, NullHandling.SetEmptyCollection, "string[]", "string[]",
+            "target.Prop1 = sourceClass.Prop1 ?? global::System.Array.Empty<string>();"
+        };
+
+        yield return new object[]
+        {
+            22, false, false, NullHandling.SetEmptyCollection, "MiddleClass[]", "MiddleClass[]",
+            "target.Prop1 = sourceClass.Prop1 ?? global::System.Array.Empty<global::MapTo.Tests.MiddleClass>();"
+        };
+
+        yield return new object[]
+        {
+            23, false, false, NullHandling.SetEmptyCollection, "List<MiddleClass>", "IEnumerable<MappedMiddleClass>",
+            "target.Prop1 = sourceClass.Prop1?.Select<global::MapTo.Tests.MiddleClass, global::MapTo.Tests.MappedMiddleClass>(global::MapTo.Tests.MiddleClassMapToExtensions.MapToMappedMiddleClass).ToArray() ?? global::System.Linq.Enumerable.Empty<global::MapTo.Tests.MappedMiddleClass>();"
+        };
+
+        yield return new object[]
+        {
+            24, false, false, NullHandling.SetEmptyCollection, "IList<string>", "IList<string>",
+            "target.Prop1 = sourceClass.Prop1 ?? new global::System.Collections.Generic.List<string>();"
+        };
+
+        yield return new object[]
+        {
+            25, false, true, NullHandling.SetEmptyCollection, "List<int>", "List<int>",
+            "target.Prop1 = sourceClass.Prop1 ?? new global::System.Collections.Generic.List<int>();"
+        };
+
+        yield return new object[]
+        {
+            26, false, true, NullHandling.SetEmptyCollection, "string[]", "string[]",
+            "target.Prop1 = sourceClass.Prop1 is null ? global::System.Array.Empty<string>() : MapToStringArray(sourceClass.Prop1);"
+        };
+
+        yield return new object[]
+        {
+            27, false, true, NullHandling.SetEmptyCollection, "MiddleClass[]", "MiddleClass[]",
+            "target.Prop1 = sourceClass.Prop1 is null ? global::System.Array.Empty<global::MapTo.Tests.MiddleClass>() : MapToMiddleClassArray(sourceClass.Prop1);"
+        };
+
+        yield return new object[]
+        {
+            28, false, true, NullHandling.SetEmptyCollection, "List<MiddleClass>", "IEnumerable<MappedMiddleClass>",
+            "target.Prop1 = sourceClass.Prop1?.Select<global::MapTo.Tests.MiddleClass, global::MapTo.Tests.MappedMiddleClass>(global::MapTo.Tests.MiddleClassMapToExtensions.MapToMappedMiddleClass).ToArray() ?? global::System.Linq.Enumerable.Empty<global::MapTo.Tests.MappedMiddleClass>();"
+        };
+
+        yield return new object[]
+        {
+            29, false, true, NullHandling.SetEmptyCollection, "IList<string>", "IList<string>",
+            "target.Prop1 = sourceClass.Prop1 ?? new global::System.Collections.Generic.List<string>();"
+        };
+
+        yield return new object[]
+        {
+            30, true, false, NullHandling.SetEmptyCollection, "int[]", "int[]",
+            "target.Prop1 = sourceClass.Prop1 ?? global::System.Array.Empty<int>();"
+        };
+
+        yield return new object[]
+        {
+            31, true, false, NullHandling.SetEmptyCollection, "int[]", "int[]?",
+            "target.Prop1 = sourceClass.Prop1 ?? global::System.Array.Empty<int>();"
+        };
+
+        yield return new object[]
+        {
+            32, true, false, NullHandling.SetEmptyCollection, "string[]", "string?[]",
+            "target.Prop1 = sourceClass.Prop1 ?? global::System.Array.Empty<string?>();"
+        };
+
+        yield return new object[]
+        {
+            33, true, true, NullHandling.SetEmptyCollection, "int[]", "int[]",
+            "target.Prop1 = sourceClass.Prop1 is null ? global::System.Array.Empty<int>() : MapToInt32Array(sourceClass.Prop1);"
+        };
+
+        yield return new object[]
+        {
+            34, true, true, NullHandling.SetEmptyCollection, "string[]", "string?[]",
+            "target.Prop1 = sourceClass.Prop1 is null ? global::System.Array.Empty<string?>() : MapToStringArray(sourceClass.Prop1);"
+        };
+    }
+
+    [SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1204:Static elements should appear before instance elements", Justification = "Test data")]
+    public static IEnumerable<object[]> CollectionNullHandlingSetNullTestData()
+    {
+        yield return new object[]
+        {
+            35, false, false, NullHandling.SetNull, "List<int>", "List<int>",
+            "target.Prop1 = sourceClass.Prop1;"
+        };
+
+        yield return new object[]
+        {
+            36, false, false, NullHandling.SetNull, "string[]", "string[]",
+            "target.Prop1 = sourceClass.Prop1;"
+        };
+
+        yield return new object[]
+        {
+            37, false, false, NullHandling.SetNull, "MiddleClass[]", "MiddleClass[]",
+            "target.Prop1 = sourceClass.Prop1;"
+        };
+
+        yield return new object[]
+        {
+            38, false, false, NullHandling.SetNull, "List<MiddleClass>", "IEnumerable<MappedMiddleClass>",
+            """
+            if (sourceClass.Prop1 is not null)
+            {
+                target.Prop1 = sourceClass.Prop1.Select<global::MapTo.Tests.MiddleClass, global::MapTo.Tests.MappedMiddleClass>(global::MapTo.Tests.MiddleClassMapToExtensions.MapToMappedMiddleClass).ToArray();
+            }
+            """
+        };
+
+        yield return new object[]
+        {
+            39, false, false, NullHandling.SetNull, "IList<string>", "IList<string>",
+            "target.Prop1 = sourceClass.Prop1;"
+        };
+
+        yield return new object[]
+        {
+            40, false, true, NullHandling.SetNull, "List<int>", "List<int>",
+            "target.Prop1 = sourceClass.Prop1;"
+        };
+
+        yield return new object[]
+        {
+            41, false, true, NullHandling.SetNull, "string[]", "string[]",
+            """
+            if (sourceClass.Prop1 is not null)
+            {
+                target.Prop1 = MapToStringArray(sourceClass.Prop1);
+            }
+            """
+        };
+
+        yield return new object[]
+        {
+            42, false, true, NullHandling.SetNull, "MiddleClass[]", "MiddleClass[]",
+            """
+            if (sourceClass.Prop1 is not null)
+            {
+                target.Prop1 = MapToMiddleClassArray(sourceClass.Prop1);
+            }
+            """
+        };
+
+        yield return new object[]
+        {
+            43, false, true, NullHandling.SetNull, "List<MiddleClass>", "IEnumerable<MappedMiddleClass>",
+            """
+            if (sourceClass.Prop1 is not null)
+            {
+                target.Prop1 = sourceClass.Prop1.Select<global::MapTo.Tests.MiddleClass, global::MapTo.Tests.MappedMiddleClass>(global::MapTo.Tests.MiddleClassMapToExtensions.MapToMappedMiddleClass).ToArray();
+            }
+            """
+        };
+
+        yield return new object[]
+        {
+            44, false, true, NullHandling.SetNull, "IList<string>", "IList<string>",
+            "target.Prop1 = sourceClass.Prop1;"
+        };
+
+        yield return new object[]
+        {
+            45, true, false, NullHandling.SetNull, "int[]", "int[]?",
+            "target.Prop1 = sourceClass.Prop1;"
+        };
+
+        yield return new object[]
+        {
+            46, true, false, NullHandling.SetNull, "MiddleClass[]?", "MiddleClass[]",
+            "target.Prop1 = sourceClass.Prop1;"
+        };
+
+        yield return new object[]
+        {
+            47, true, false, NullHandling.SetNull, "List<MiddleClass>", "IEnumerable<MappedMiddleClass?>",
+            """
+            if (sourceClass.Prop1 is not null)
+            {
+                target.Prop1 = sourceClass.Prop1.Select<global::MapTo.Tests.MiddleClass, global::MapTo.Tests.MappedMiddleClass?>(global::MapTo.Tests.MiddleClassMapToExtensions.MapToMappedMiddleClass).ToArray();
+            }
+            """
+        };
+
+        yield return new object[]
+        {
+            48, true, false, NullHandling.SetNull, "IList<string>", "IList<string>",
+            "target.Prop1 = sourceClass.Prop1;"
+        };
+
+        yield return new object[]
+        {
+            49, true, true, NullHandling.SetNull, "List<int>", "List<int>",
+            "target.Prop1 = sourceClass.Prop1;"
+        };
+
+        yield return new object[]
+        {
+            50, true, true, NullHandling.SetNull, "string[]", "string[]",
+            """
+            if (sourceClass.Prop1 is not null)
+            {
+                target.Prop1 = MapToStringArray(sourceClass.Prop1);
+            }
+            """
+        };
+
+        yield return new object[]
+        {
+            51, true, true, NullHandling.SetNull, "MiddleClass[]", "MiddleClass[]",
+            """
+            if (sourceClass.Prop1 is not null)
+            {
+                target.Prop1 = MapToMiddleClassArray(sourceClass.Prop1);
+            }
+            """
+        };
+
+        yield return new object[]
+        {
+            52, true, true, NullHandling.SetNull, "List<MiddleClass?>", "IEnumerable<MappedMiddleClass?>",
+            """
+            if (sourceClass.Prop1 is not null)
+            {
+                target.Prop1 = sourceClass.Prop1.Select<global::MapTo.Tests.MiddleClass?, global::MapTo.Tests.MappedMiddleClass?>(global::MapTo.Tests.MiddleClassMapToExtensions.MapToMappedMiddleClass).ToArray();
+            }
+            """
+        };
+
+        yield return new object[]
+        {
+            53, true, true, NullHandling.SetNull, "IList<string>?", "IList<string>?",
+            "target.Prop1 = sourceClass.Prop1;"
+        };
+    }
+
+    [SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1204:Static elements should appear before instance elements", Justification = "Test data")]
+    public static IEnumerable<object[]> CollectionNullHandlingAutoTestData()
+    {
+        yield return new object[]
+        {
+            54, true, false, NullHandling.Auto, "int[]?", "int[]?",
+            "target.Prop1 = sourceClass.Prop1;"
+        };
+
+        yield return new object[]
+        {
+            55, true, false, NullHandling.Auto, "int[]?", "int[]",
+            "target.Prop1 = sourceClass.Prop1 ?? global::System.Array.Empty<int>();"
+        };
+
+        yield return new object[]
+        {
+            56, true, false, NullHandling.Auto, "int[]", "int[]?",
+            "target.Prop1 = sourceClass.Prop1;"
+        };
+
+        yield return new object[]
+        {
+            57, true, false, NullHandling.Auto, "int[]", "int[]",
+            "target.Prop1 = sourceClass.Prop1;"
+        };
+
+        yield return new object[]
+        {
+            58, true, false, NullHandling.Auto, "List<MiddleClass>", "IEnumerable<MiddleClass>",
+            "target.Prop1 = sourceClass.Prop1;"
+        };
+
+        yield return new object[]
+        {
+            59, true, false, NullHandling.Auto, "List<MiddleClass>", "IEnumerable<MiddleClass>?",
+            "target.Prop1 = sourceClass.Prop1"
+        };
+
+        yield return new object[]
+        {
+            60, true, false, NullHandling.Auto, "List<MiddleClass>?", "IEnumerable<MiddleClass>",
+            "target.Prop1 = sourceClass.Prop1 ?? global::System.Linq.Enumerable.Empty<global::MapTo.Tests.MiddleClass>();"
+        };
+
+        yield return new object[]
+        {
+            61, true, false, NullHandling.Auto, "List<MiddleClass>?", "IEnumerable<MiddleClass>?",
+            "target.Prop1 = sourceClass.Prop1"
+        };
+
+        yield return new object[]
+        {
+            62, true, false, NullHandling.Auto, "List<MiddleClass>", "IEnumerable<MappedMiddleClass>",
+            "target.Prop1 = sourceClass.Prop1.Select<global::MapTo.Tests.MiddleClass, global::MapTo.Tests.MappedMiddleClass>(global::MapTo.Tests.MiddleClassMapToExtensions.MapToMappedMiddleClass).ToArray()"
+        };
+
+        yield return new object[]
+        {
+            67, true, false, NullHandling.Auto, "List<MiddleClass>", "IEnumerable<MappedMiddleClass>?",
+            "target.Prop1 = sourceClass.Prop1.Select<global::MapTo.Tests.MiddleClass, global::MapTo.Tests.MappedMiddleClass>(global::MapTo.Tests.MiddleClassMapToExtensions.MapToMappedMiddleClass).ToArray()"
+        };
+
+        yield return new object[]
+        {
+            68, true, false, NullHandling.Auto, "List<MiddleClass>?", "IEnumerable<MappedMiddleClass>",
+            "target.Prop1 = sourceClass.Prop1?.Select<global::MapTo.Tests.MiddleClass, global::MapTo.Tests.MappedMiddleClass>(global::MapTo.Tests.MiddleClassMapToExtensions.MapToMappedMiddleClass).ToArray() ?? global::System.Linq.Enumerable.Empty<global::MapTo.Tests.MappedMiddleClass>();"
+        };
+
+        yield return new object[]
+        {
+            69, true, false, NullHandling.Auto, "List<MiddleClass>?", "IEnumerable<MappedMiddleClass>?",
+            "target.Prop1 = sourceClass.Prop1?.Select<global::MapTo.Tests.MiddleClass, global::MapTo.Tests.MappedMiddleClass>(global::MapTo.Tests.MiddleClassMapToExtensions.MapToMappedMiddleClass).ToArray()"
+        };
+
+        yield return new object[]
+        {
+            70, true, true, NullHandling.Auto, "int[]?", "int[]?",
+            """
+            if (sourceClass.Prop1 is not null)
+            {
+                target.Prop1 = MapToInt32Array(sourceClass.Prop1);
+            }
+            """
+        };
+
+        yield return new object[]
+        {
+            71, true, true, NullHandling.Auto, "int[]?", "int[]",
+            "target.Prop1 = sourceClass.Prop1 is null ? global::System.Array.Empty<int>() : MapToInt32Array(sourceClass.Prop1);"
+        };
+
+        yield return new object[]
+        {
+            72, true, true, NullHandling.Auto, "int[]", "int[]?",
+            "target.Prop1 = MapToInt32Array(sourceClass.Prop1);"
+        };
+
+        yield return new object[]
+        {
+            73, true, true, NullHandling.Auto, "int[]", "int[]",
+            "target.Prop1 = MapToInt32Array(sourceClass.Prop1);"
+        };
+
+        yield return new object[]
+        {
+            74, true, true, NullHandling.Auto, "List<MiddleClass>", "IEnumerable<MiddleClass>",
+            "target.Prop1 = sourceClass.Prop1;"
+        };
+
+        yield return new object[]
+        {
+            75, true, true, NullHandling.Auto, "List<MiddleClass>", "IEnumerable<MiddleClass>?",
+            "target.Prop1 = sourceClass.Prop1"
+        };
+
+        yield return new object[]
+        {
+            76, true, true, NullHandling.Auto, "List<MiddleClass>?", "IEnumerable<MiddleClass>",
+            "target.Prop1 = sourceClass.Prop1 ?? global::System.Linq.Enumerable.Empty<global::MapTo.Tests.MiddleClass>();"
+        };
+
+        yield return new object[]
+        {
+            77, true, true, NullHandling.Auto, "List<MiddleClass>?", "IEnumerable<MiddleClass>?",
+            "target.Prop1 = sourceClass.Prop1"
+        };
+
+        yield return new object[]
+        {
+            78, true, true, NullHandling.Auto, "List<MiddleClass>", "IEnumerable<MappedMiddleClass>",
+            "target.Prop1 = sourceClass.Prop1.Select<global::MapTo.Tests.MiddleClass, global::MapTo.Tests.MappedMiddleClass>(global::MapTo.Tests.MiddleClassMapToExtensions.MapToMappedMiddleClass).ToArray();"
+        };
+
+        yield return new object[]
+        {
+            79, true, true, NullHandling.Auto, "List<MiddleClass>", "IEnumerable<MappedMiddleClass>?",
+            "target.Prop1 = sourceClass.Prop1.Select<global::MapTo.Tests.MiddleClass, global::MapTo.Tests.MappedMiddleClass>(global::MapTo.Tests.MiddleClassMapToExtensions.MapToMappedMiddleClass).ToArray();"
+        };
+
+        yield return new object[]
+        {
+            80, true, true, NullHandling.Auto, "List<MiddleClass>?", "IEnumerable<MappedMiddleClass>",
+            "target.Prop1 = sourceClass.Prop1?.Select<global::MapTo.Tests.MiddleClass, global::MapTo.Tests.MappedMiddleClass>(global::MapTo.Tests.MiddleClassMapToExtensions.MapToMappedMiddleClass).ToArray() ?? global::System.Linq.Enumerable.Empty<global::MapTo.Tests.MappedMiddleClass>();"
+        };
+
+        yield return new object[]
+        {
+            81, true, true, NullHandling.Auto, "List<MiddleClass>?", "IEnumerable<MappedMiddleClass>?",
+            "target.Prop1 = sourceClass.Prop1?.Select<global::MapTo.Tests.MiddleClass, global::MapTo.Tests.MappedMiddleClass>(global::MapTo.Tests.MiddleClassMapToExtensions.MapToMappedMiddleClass).ToArray();"
+        };
+    }
+}

--- a/test/MapTo.Tests/ReferenceHandlingTests.cs
+++ b/test/MapTo.Tests/ReferenceHandlingTests.cs
@@ -95,7 +95,7 @@ public class ReferenceHandlingTests
             [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("manager")]
             internal static ManagerViewModel? MapToManagerViewModel(Manager? manager, global::System.Collections.Generic.Dictionary<int, object> referenceHandler)
             {
-                if (ReferenceEquals(manager, null))
+                if (manager is null)
                 {
                     return null;
                 }
@@ -113,16 +113,11 @@ public class ReferenceHandlingTests
             
                 referenceHandler.Add(manager.GetHashCode(), target);
             
-                if (!ReferenceEquals(manager.Employees, null))
-                {
-                    target.Employees = manager.Employees.Select(e => global::MapTo.Tests.EmployeeMapToExtensions.MapToEmployeeViewModel(e, referenceHandler)).ToList();
-                }
-            
-                if (!ReferenceEquals(manager.Manager, null))
+                target.Employees = manager.Employees?.Select(e => global::MapTo.Tests.EmployeeMapToExtensions.MapToEmployeeViewModel(e, referenceHandler)).ToList();
+                if (manager.Manager is not null)
                 {
                     target.Manager = global::MapTo.Tests.ManagerMapToExtensions.MapToManagerViewModel(manager.Manager, referenceHandler);
                 }
-            
                 return target;
             }
             """);
@@ -183,7 +178,7 @@ public class ReferenceHandlingTests
                 EmployeeCode = employee.EmployeeCode
             };
 
-            if (!ReferenceEquals(employee.Manager, null))
+            if (employee.Manager is not null)
             {
                 target.Manager = global::MapTo.Tests.ManagerMapToExtensions.MapToManagerViewModel(employee.Manager);
             }

--- a/test/MapTo.Tests/ReferenceHandlingTests.cs
+++ b/test/MapTo.Tests/ReferenceHandlingTests.cs
@@ -58,7 +58,6 @@ public class ReferenceHandlingTests
         var (compilation, diagnostics) = builder.Compile(assertOutputCompilation: true);
 
         // Assert
-        compilation.Dump(_output);
         var targetClassDeclaration = compilation.GetClassDeclaration("TargetClass", "TestFile1.g.cs").ShouldNotBeNull();
         var constructorDeclarationSyntax = targetClassDeclaration.DescendantNodes().OfType<ConstructorDeclarationSyntax>().Single();
         var parameter = constructorDeclarationSyntax.ParameterList.Parameters.First();
@@ -159,7 +158,6 @@ public class ReferenceHandlingTests
         var (compilation, diagnostics) = builder.Compile();
 
         // Assert
-        compilation.Dump(_output);
         diagnostics.ShouldBeSuccessful();
 
         var managerExtensionClass = compilation.GetClassDeclaration("ManagerMapToExtensions", "MapTo.Tests.ManagerViewModel.g.cs");

--- a/test/MapTo.Tests/ScenarioBuilder.cs
+++ b/test/MapTo.Tests/ScenarioBuilder.cs
@@ -64,7 +64,7 @@ internal static class ScenarioBuilder
 
     public static ITestSourceBuilder SimpleMappedClassInSameNamespaceAsSourceWithInitProperty(LanguageVersion version = LanguageVersion.CSharp10)
     {
-        var builder = new TestSourceBuilder(TestSourceBuilderOptions.Create(version));
+        var builder = new TestSourceBuilder(TestSourceBuilderOptions.Create(version, supportNullReferenceTypes: false));
         var sourceFile = builder.AddFile();
         sourceFile.AddClass(Accessibility.Public, "SourceClass").WithProperty<int>("Id").WithProperty<string>("Name");
         sourceFile.AddClass(Accessibility.Public, "TargetClass", attributes: "[MapFrom(typeof(SourceClass))]")
@@ -79,10 +79,12 @@ internal static class ScenarioBuilder
 
     public static ITestSourceBuilder BuildEmployeeManagerModels(
         LanguageVersion version = LanguageVersion.CSharp10,
-        ReferenceHandling referenceHandling = ReferenceHandling.Disabled)
+        ReferenceHandling referenceHandling = ReferenceHandling.Disabled) => BuildEmployeeManagerModels(TestSourceBuilderOptions.Create(version), referenceHandling);
+
+    public static ITestSourceBuilder BuildEmployeeManagerModels(TestSourceBuilderOptions options, ReferenceHandling referenceHandling = ReferenceHandling.Disabled)
     {
         var globalUsings = new[] { "System.Collections.Generic" };
-        var builder = new TestSourceBuilder(TestSourceBuilderOptions.Create(version));
+        var builder = new TestSourceBuilder(options);
         var employeeFile = builder.AddFile("Employee", usings: globalUsings);
 
         employeeFile.AddClass("""
@@ -236,7 +238,7 @@ internal static class ScenarioBuilder
                 [return: {{NotNullIfNotNull}}("sourceClass")]
                 public static TargetClass? MapToTargetClass(this SourceClass? sourceClass)
                 {
-                    if (ReferenceEquals(sourceClass, null))
+                    if (sourceClass is null)
                     {
                         return null;
                     }
@@ -256,7 +258,7 @@ internal static class ScenarioBuilder
                 [return: {{NotNullIfNotNull}}("sourceClass")]
                 public static TargetClass MapToTargetClass([{{AllowNull}}] this SourceClass sourceClass)
                 {
-                    if (ReferenceEquals(sourceClass, null))
+                    if (sourceClass is null)
                     {
                         return null;
                     }

--- a/test/MapTo.Tests/SourceBuilders/TestSourceBuilder.cs
+++ b/test/MapTo.Tests/SourceBuilders/TestSourceBuilder.cs
@@ -7,6 +7,9 @@ internal class TestSourceBuilder : ITestSourceBuilder
 {
     private readonly List<ITestFileBuilder> _files = new();
 
+    internal TestSourceBuilder(bool supportNullReferenceTypes, IDictionary<string, string>? analyzerConfigOptions)
+        : this(TestSourceBuilderOptions.Create(supportNullReferenceTypes: supportNullReferenceTypes, analyzerConfigOptions: analyzerConfigOptions)) { }
+
     internal TestSourceBuilder(TestSourceBuilderOptions? options = null)
     {
         Options = options ?? TestSourceBuilderOptions.Create();


### PR DESCRIPTION
- Automatically handling nullable reference types via their nullability context for collections and reference type properties.
- Allow to manually set the null handling strategy via the `NullHandling` configuration option.