### PR TITLE
Add support for flattening

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,9 +17,9 @@ on:
   pull_request:
     branches:
       - '**'
-  push:
-    branches:
-      - 'dev/**'
+#  push:
+#    branches:
+#      - 'dev/**'
 env:
   BUILD_CONFIGURATION: ${{ inputs.build-configuration || 'Debug' }}
   DOTNET_VERSION: ${{ inputs.dotnet-version || '7.0.x' }}

--- a/benchmarks/MapTo.Benchmarks/MapTo.Benchmarks.csproj
+++ b/benchmarks/MapTo.Benchmarks/MapTo.Benchmarks.csproj
@@ -5,7 +5,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
-        <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+        <EmitCompilerGeneratedFiles>false</EmitCompilerGeneratedFiles>
 
         <MapTo_ReferenceHandling>Disabled</MapTo_ReferenceHandling>
     </PropertyGroup>

--- a/src/MapTo/CodeAnalysis/SymbolExtensions.cs
+++ b/src/MapTo/CodeAnalysis/SymbolExtensions.cs
@@ -131,4 +131,12 @@ internal static class SymbolExtensions
 
     public static string ToFullyQualifiedDisplayString(this ITypeSymbol typeSymbol) =>
         $"{typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}{(typeSymbol.NullableAnnotation is NullableAnnotation.Annotated ? "?" : string.Empty)}";
+
+    public static T? GetSymbolOrBestCandidate<T>(this SymbolInfo symbolInfo)
+        where T : class, ISymbol => symbolInfo switch
+    {
+        { Symbol: { } symbol } => symbol as T,
+        { CandidateReason: CandidateReason.MemberGroup, CandidateSymbols: { Length: 1 } candidateSymbols } => candidateSymbols[0] as T,
+        _ => null
+    };
 }

--- a/src/MapTo/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/MapTo/Diagnostics/DiagnosticDescriptors.cs
@@ -112,7 +112,7 @@ internal static class DiagnosticDescriptors
     internal static readonly DiagnosticDescriptor BeforeOrAfterMapMethodNotFoundError = new DiagnosticDescriptor(
         id: $"{ErrorId}012",
         title: string.Empty,
-        messageFormat: "Unable to find '{0}' method. Make sure a matching static method exists it is accessible.",
+        messageFormat: "Unable to find '{0}' method. Make sure a matching static method exists and it is accessible.",
         category: UsageCategory,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);

--- a/src/MapTo/Diagnostics/DiagnosticsFactory.cs
+++ b/src/MapTo/Diagnostics/DiagnosticsFactory.cs
@@ -45,13 +45,17 @@ internal static class DiagnosticsFactory
         property.ToDisplayString(),
         property.Type.ToDisplayString());
 
-    internal static Diagnostic PropertyTypeConverterMethodInputTypeCompatibilityError(IPropertySymbol sourceProperty, IMethodSymbol converterMethodSymbol) => Create(
-        DiagnosticDescriptors.PropertyTypeConverterMethodInputTypeCompatibilityError,
-        converterMethodSymbol.Parameters[0].GetLocation(),
-        converterMethodSymbol.Parameters[0].Type.ToDisplayString(),
-        converterMethodSymbol.Name,
-        sourceProperty.ToDisplayString(),
-        sourceProperty.Type.ToDisplayString());
+    internal static Diagnostic PropertyTypeConverterMethodInputTypeCompatibilityError(
+        string sourcePropertyName,
+        ITypeSymbol sourcePropertyType,
+        IMethodSymbol converterMethodSymbol) =>
+        Create(
+            DiagnosticDescriptors.PropertyTypeConverterMethodInputTypeCompatibilityError,
+            converterMethodSymbol.Parameters[0].GetLocation(),
+            converterMethodSymbol.Parameters[0].Type.ToDisplayString(),
+            converterMethodSymbol.Name,
+            sourcePropertyName,
+            sourcePropertyType.ToDisplayString());
 
     internal static Diagnostic PropertyTypeConverterMethodAdditionalParametersTypeCompatibilityError(IMethodSymbol converterMethodSymbol) => Create(
         DiagnosticDescriptors.PropertyTypeConverterMethodAdditionalParametersTypeCompatibilityError,
@@ -59,10 +63,10 @@ internal static class DiagnosticsFactory
         converterMethodSymbol.Parameters[1].Type.ToDisplayString(),
         converterMethodSymbol.Name);
 
-    internal static Diagnostic PropertyTypeConverterMethodInputTypeNullCompatibilityError(IPropertySymbol sourceProperty, IMethodSymbol converterMethodSymbol) => Create(
+    internal static Diagnostic PropertyTypeConverterMethodInputTypeNullCompatibilityError(string sourcePropertyName, IMethodSymbol converterMethodSymbol) => Create(
         DiagnosticDescriptors.PropertyTypeConverterMethodInputTypeNullCompatibilityError,
         converterMethodSymbol.Parameters[0].GetLocation(),
-        sourceProperty.ToDisplayString(),
+        sourcePropertyName,
         converterMethodSymbol.Name,
         converterMethodSymbol.Parameters[0].Name);
 

--- a/src/MapTo/Generators/Handlers/ArrayPropertyMappingGenerator.cs
+++ b/src/MapTo/Generators/Handlers/ArrayPropertyMappingGenerator.cs
@@ -108,9 +108,9 @@ internal sealed class ArrayPropertyMappingGenerator : PropertyMappingGenerator
             {
                 { IsMapToExtensionMethod: false } when !copyPrimitiveArrays => writer.Write(parameterName),
                 { IsMapToExtensionMethod: true, ReferenceHandling: true } => writer
-                    .Write(property.TypeConverter.MethodName).Write("Array").WriteOpenParenthesis()
-                    .Write(parameterName).Write(", ").Write(refHandler).WriteClosingParenthesis(),
-                _ => writer.Write(property.TypeConverter.MethodName).Write("Array").WriteOpenParenthesis().Write(parameterName).WriteClosingParenthesis()
+                    .Write(property.TypeConverter.MethodName).Write("Array").Write("(")
+                    .Write(parameterName).Write(", ").Write(refHandler).Write(")"),
+                _ => writer.Write(property.TypeConverter.MethodName).Write("Array").Write("(").Write(parameterName).Write(")")
             };
         }
     }

--- a/src/MapTo/Generators/Handlers/TypeConverterPropertyMappingGenerator.cs
+++ b/src/MapTo/Generators/Handlers/TypeConverterPropertyMappingGenerator.cs
@@ -53,11 +53,11 @@ internal sealed class TypeConverterPropertyMappingGenerator : PropertyMappingGen
         return typeConverter switch
         {
             { HasParameter: true } => writer
-                .Write(typeConverter.MethodFullName).WriteOpenParenthesis().Write(parameterName).Write(", ").Write(typeConverter.Parameter).WriteClosingParenthesis(),
+                .Write(typeConverter.MethodFullName).Write("(").Write(parameterName).Write(", ").Write(typeConverter.Parameter).Write(")"),
             { HasParameter: false, ReferenceHandling: false } => writer
-                .Write(typeConverter.MethodFullName).WriteOpenParenthesis().Write(parameterName).WriteClosingParenthesis(),
+                .Write(typeConverter.MethodFullName).Write("(").Write(parameterName).Write(")"),
             { HasParameter: false, ReferenceHandling: true } => writer
-                .Write(typeConverter.MethodFullName).WriteOpenParenthesis().Write(parameterName).Write(", ").Write(referenceHandlerName).WriteClosingParenthesis()
+                .Write(typeConverter.MethodFullName).Write("(").Write(parameterName).Write(", ").Write(referenceHandlerName).Write(")")
         };
     }
 }

--- a/test/MapTo.Tests/FlatteningTests.cs
+++ b/test/MapTo.Tests/FlatteningTests.cs
@@ -1,0 +1,86 @@
+﻿namespace MapTo.Tests;
+
+public class FlatteningTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public FlatteningTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public void When_MappingToDifferentProperty_Should_HandleNestedProperty()
+    {
+        // Arrange
+        var builder = ScenarioBuilder.ProductOrderAndOrderLineItem();
+        var file = builder.AddFile("FlatteningTest", supportNullableReferenceTypes: true);
+        file.AddClass(Accessibility.Public, "OrderDto", attributes: new[] { "[MapFrom(typeof(Order))]" })
+            .WithProperty("string?", "CustomerName", attributes: new[] { """[MapProperty(From = "Customer.Name")]""" });
+
+        // Act
+        var (compilation, diagnostics) = builder.Compile();
+
+        // Assert
+        diagnostics.ShouldBeSuccessful();
+
+        var extensionClass = compilation.GetClassDeclaration("OrderMapToExtensions", "MapTo.Tests.OrderDto.g.cs").ShouldNotBeNull();
+        extensionClass.ShouldContain(
+            """
+            return new OrderDto
+            {
+                CustomerName = order.Customer?.Name
+            };
+            """);
+    }
+
+    [Theory]
+    [InlineData("[MapProperty(From = nameof(Order.Customer.Name))]")]
+    [InlineData("""[MapProperty(From = "Customer.Name")]""")]
+    public void When_MappingToDifferentNotNullProperty_Should_HandleNestedProperty(string mapPropertyAttribute)
+    {
+        // Arrange
+        var builder = ScenarioBuilder.ProductOrderAndOrderLineItem();
+        var file = builder.AddFile("FlatteningTest", supportNullableReferenceTypes: true);
+        file.AddClass(Accessibility.Public, "OrderDto", attributes: new[] { "[MapFrom(typeof(Order))]" })
+            .WithProperty<string>("CustomerName", attribute: mapPropertyAttribute, defaultValue: "null!");
+
+        // Act
+        var (compilation, diagnostics) = builder.Compile();
+
+        // Assert
+        diagnostics.ShouldBeSuccessful();
+
+        var extensionClass = compilation.GetClassDeclaration("OrderMapToExtensions", "MapTo.Tests.OrderDto.g.cs").ShouldNotBeNull();
+        extensionClass.ShouldContain(
+            """
+            return new OrderDto
+            {
+                CustomerName = order.Customer?.Name ?? string.Empty
+            };
+            """);
+    }
+
+    [Theory]
+    [InlineData("""[MapProperty(From = "GetTotal")]""")]
+    [InlineData("""[MapProperty(From = "Order.GetTotal")]""")]
+    [InlineData("[MapProperty(From = nameof(Order.GetTotal))]")]
+    public void When_MappingToMethodName_Should_AllowParameterLessMethodMembers(string mapPropertyAttribute)
+    {
+        // Arrange
+        var builder = ScenarioBuilder.ProductOrderAndOrderLineItem();
+        var file = builder.AddFile("FlatteningTest", supportNullableReferenceTypes: true);
+        file.AddClass(Accessibility.Public, "OrderDto", attributes: new[] { "[MapFrom(typeof(Order))]" })
+            .WithProperty<decimal>("Total", attribute: mapPropertyAttribute);
+
+        // Act
+        var (compilation, diagnostics) = builder.Compile();
+
+        // Assert
+        compilation.Dump(_output);
+        diagnostics.ShouldBeSuccessful();
+
+        var extensionClass = compilation.GetClassDeclaration("OrderMapToExtensions", "MapTo.Tests.OrderDto.g.cs").ShouldNotBeNull();
+        extensionClass.ShouldContain("target.Total = order.GetTotal();");
+    }
+}

--- a/test/MapTo.Tests/PropertyTypeConverterTests.cs
+++ b/test/MapTo.Tests/PropertyTypeConverterTests.cs
@@ -179,7 +179,10 @@ public class PropertyTypeConverterTests
         var targetSemanticModel = compilation.GetSemanticModel(targetClassDeclaration.SyntaxTree);
         var targetMethodSymbol = (targetSemanticModel.GetDeclaredSymbol(targetClassDeclaration.Members[2]) as IMethodSymbol).ShouldNotBeNull();
 
-        diagnostics.ShouldNotBeSuccessful(DiagnosticsFactory.PropertyTypeConverterMethodInputTypeCompatibilityError(sourcePropertySymbol, targetMethodSymbol));
+        diagnostics.ShouldNotBeSuccessful(DiagnosticsFactory.PropertyTypeConverterMethodInputTypeCompatibilityError(
+            sourcePropertySymbol.ToDisplayString(),
+            sourcePropertySymbol.Type,
+            targetMethodSymbol));
     }
 
     [Theory]
@@ -281,6 +284,6 @@ public class PropertyTypeConverterTests
         var methodSymbol = semanticModel.GetDeclaredSymbol(targetClassDeclaration.Members[2]) as IMethodSymbol;
 
         methodSymbol.ShouldNotBeNull();
-        diagnostics.ShouldNotBeSuccessful(DiagnosticsFactory.PropertyTypeConverterMethodInputTypeNullCompatibilityError(sourceProperty, methodSymbol));
+        diagnostics.ShouldNotBeSuccessful(DiagnosticsFactory.PropertyTypeConverterMethodInputTypeNullCompatibilityError(sourceProperty.Name, methodSymbol));
     }
 }


### PR DESCRIPTION
Add support mapping to complex object models and flatten it to a simpler model.
Supports both nested property calls and map to source class parameterless methods.