### PR TITLE
Allow return type and source property in after map methods.

### DIFF
--- a/src/MapTo/AnalyzerReleases.Shipped.md
+++ b/src/MapTo/AnalyzerReleases.Shipped.md
@@ -21,4 +21,5 @@
  MT3014  | Mapping  | Error    | Before or after map method has invalid return type.                                              
  MT3015  | Mapping  | Error    | Before or after map method parameter is missing.                                                 
  MT3016  | Mapping  | Error    | Before or after map method parameter has inconsistent nullability annotation.                    
- MT3017  | Mapping  | Error    | Before or after map method return type has inconsistent nullability annotation.                  
+ MT3017  | Mapping  | Error    | Before or after map method return type has inconsistent nullability annotation.
+ MT3018  | Mapping  | Error    | After map method does not have correct number of parameters.

--- a/src/MapTo/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/MapTo/Diagnostics/DiagnosticDescriptors.cs
@@ -2,7 +2,7 @@
 
 [SuppressMessage(category: "Style", checkId: "IDE0090:Use \'new(...)\'", Justification = "Is not supported. https://github.com/dotnet/roslyn-analyzers/issues/5828")]
 [SuppressMessage(category: "StyleCop.CSharp.OrderingRules", checkId: "SA1202:Elements should be ordered by access", Justification = "To improve diagnostics messages readability.")]
-[SuppressMessage(category: "StyleCop.CSharp.ReadabilityRules", checkId: "SA1118:Parameter should not span multiple lines", Justification ="To improve diagnostics messages readability.")]
+[SuppressMessage(category: "StyleCop.CSharp.ReadabilityRules", checkId: "SA1118:Parameter should not span multiple lines", Justification = "To improve diagnostics messages readability.")]
 internal static class DiagnosticDescriptors
 {
     private const string CodePrefix = "MT";
@@ -11,6 +11,9 @@ internal static class DiagnosticDescriptors
     private const string WarningId = $"{CodePrefix}2";
     private const string ErrorId = $"{CodePrefix}3";
 
+    /// <summary>
+    /// Additional parameters are provided to the '{0}' property type converter, but the '{1}' method does not have a second parameter of type object[].
+    /// </summary>
     internal static readonly DiagnosticDescriptor PropertyTypeConverterMethodAdditionalParametersIsMissingWarning = new DiagnosticDescriptor(
         id: $"{WarningId}001",
         title: string.Empty,
@@ -19,6 +22,9 @@ internal static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
 
+    /// <summary>
+    /// Missing 'partial' keyword on '{0}' class.
+    /// </summary>
     internal static readonly DiagnosticDescriptor MissingPartialKeywordOnTargetClassError = new DiagnosticDescriptor(
         id: $"{ErrorId}001",
         title: string.Empty,
@@ -27,6 +33,9 @@ internal static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
+    /// <summary>
+    /// Missing constructor on '{0}' class.
+    /// </summary>
     internal static readonly DiagnosticDescriptor MissingConstructorOnTargetClassError = new DiagnosticDescriptor(
         id: $"{ErrorId}002",
         title: string.Empty,
@@ -35,6 +44,10 @@ internal static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
+    /// <summary>
+    /// Cannot create a map for '{0}' property because source and destination types are not implicitly convertible.
+    /// Consider using '{1}' to provide a type converter or ignore the property using '{2}'.
+    /// </summary>
     internal static readonly DiagnosticDescriptor PropertyTypeConverterRequiredError = new DiagnosticDescriptor(
         id: $"{ErrorId}003",
         title: string.Empty,
@@ -44,6 +57,9 @@ internal static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
+    /// <summary>
+    /// Unable to find '{0}' method. Make sure a matching static method exists in the '{1}' and it is accessible.
+    /// </summary>
     internal static readonly DiagnosticDescriptor PropertyTypeConverterMethodNotFoundInTargetClassError = new DiagnosticDescriptor(
         id: $"{ErrorId}004",
         title: string.Empty,
@@ -52,6 +68,9 @@ internal static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
+    /// <summary>
+    /// The '{0}' method must be static.
+    /// </summary>
     internal static readonly DiagnosticDescriptor PropertyTypeConverterMethodIsNotStaticError = new DiagnosticDescriptor(
         id: $"{ErrorId}005",
         title: string.Empty,
@@ -60,6 +79,9 @@ internal static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
+    /// <summary>
+    /// The '{0}' method return type '{1}' is not compatible with the '{2}' property type '{3}'.
+    /// </summary>
     internal static readonly DiagnosticDescriptor PropertyTypeConverterMethodReturnTypeCompatibilityError = new DiagnosticDescriptor(
         id: $"{ErrorId}006",
         title: string.Empty,
@@ -68,6 +90,9 @@ internal static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
+    /// <summary>
+    /// The input parameter type '{0}' of the '{1}' method is not compatible with the '{2}' property type '{3}'.
+    /// </summary>
     internal static readonly DiagnosticDescriptor PropertyTypeConverterMethodInputTypeCompatibilityError = new DiagnosticDescriptor(
         id: $"{ErrorId}007",
         title: string.Empty,
@@ -76,6 +101,9 @@ internal static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
+    /// <summary>
+    /// The additional parameters type '{0}' of the '{1}' method must be an object[].
+    /// </summary>
     internal static readonly DiagnosticDescriptor PropertyTypeConverterMethodAdditionalParametersTypeCompatibilityError = new DiagnosticDescriptor(
         id: $"{ErrorId}008",
         title: string.Empty,
@@ -84,6 +112,9 @@ internal static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
+    /// <summary>
+    /// The property '{0}' is nullable, but the '{1}' method parameter '{2}' is not.
+    /// </summary>
     internal static readonly DiagnosticDescriptor PropertyTypeConverterMethodInputTypeNullCompatibilityError = new DiagnosticDescriptor(
         id: $"{ErrorId}009",
         title: string.Empty,
@@ -92,6 +123,10 @@ internal static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
+    /// <summary>
+    /// Unable to find a suitable type to map '{0}' property. Consider annotating '{1}' using '{nameof(MapFromAttribute)}'
+    /// or ignore the property using '{nameof(IgnorePropertyAttribute)}'.
+    /// </summary>
     internal static readonly DiagnosticDescriptor SuitableMappingTypeInNestedPropertyNotFoundError = new DiagnosticDescriptor(
         id: $"{ErrorId}010",
         title: string.Empty,
@@ -101,6 +136,9 @@ internal static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
+    /// <summary>
+    /// Cannot create a map for '{0}' class because it has a self-referencing argument in the constructor.
+    /// </summary>
     internal static readonly DiagnosticDescriptor SelfReferencingConstructorMappingError = new DiagnosticDescriptor(
         id: $"{ErrorId}011",
         title: string.Empty,
@@ -109,6 +147,9 @@ internal static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
+    /// <summary>
+    /// Unable to find '{0}' method. Make sure a matching static method exists and it is accessible.
+    /// </summary>
     internal static readonly DiagnosticDescriptor BeforeOrAfterMapMethodNotFoundError = new DiagnosticDescriptor(
         id: $"{ErrorId}012",
         title: string.Empty,
@@ -117,6 +158,9 @@ internal static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
+    /// <summary>
+    /// The '{0}' method must have either no argument or a single argument assignable to the '{1}'.
+    /// </summary>
     internal static readonly DiagnosticDescriptor BeforeOrAfterMapMethodInvalidParameterError = new DiagnosticDescriptor(
         id: $"{ErrorId}013",
         title: string.Empty,
@@ -125,6 +169,9 @@ internal static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
+    /// <summary>
+    /// The '{0}' method must return void or a type that is assignable to the type '{1}'.
+    /// </summary>
     internal static readonly DiagnosticDescriptor BeforeOrAfterMapMethodInvalidReturnTypeError = new DiagnosticDescriptor(
         id: $"{ErrorId}014",
         title: string.Empty,
@@ -133,6 +180,9 @@ internal static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
+    /// <summary>
+    /// The '{0}' method must return void or a single argument assignable to the type '{1}'.
+    /// </summary>
     internal static readonly DiagnosticDescriptor BeforeOrAfterMapMethodMissingParameterError = new DiagnosticDescriptor(
         id: $"{ErrorId}015",
         title: string.Empty,
@@ -141,6 +191,9 @@ internal static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
+    /// <summary>
+    /// The argument passed to the '{0}' method might be null but it is not annotated with nullability annotation.
+    /// </summary>
     internal static readonly DiagnosticDescriptor BeforeOrAfterMapMethodMissingParameterNullabilityAnnotationError = new DiagnosticDescriptor(
         id: $"{ErrorId}016",
         title: string.Empty,
@@ -150,11 +203,25 @@ internal static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
+    /// <summary>
+    /// The '{0}' method return type might be null but it is not annotated with nullability annotation.
+    /// </summary>
     internal static readonly DiagnosticDescriptor BeforeOrAfterMapMethodMissingReturnTypeNullabilityAnnotationError = new DiagnosticDescriptor(
         id: $"{ErrorId}017",
         title: string.Empty,
         messageFormat: "The '{0}' method return type might be null but it is not annotated with nullability annotation. " +
                        "Consider annotating the argument with nullability annotation or disable nullable reference types.",
+        category: UsageCategory,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    /// <summary>
+    /// The '{0}' method must have either no argument, a single argument assignable to the '{1}' or two arguments assignable to the '{1}' and '{2}'.
+    /// </summary>
+    internal static readonly DiagnosticDescriptor AfterMapMethodInvalidParametersError = new DiagnosticDescriptor(
+        id: $"{ErrorId}018",
+        title: string.Empty,
+        messageFormat: "The '{0}' method must have either no argument, a single argument assignable to the '{1}' or two arguments assignable to the '{1}' and '{2}'",
         category: UsageCategory,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);

--- a/src/MapTo/Diagnostics/DiagnosticsFactory.cs
+++ b/src/MapTo/Diagnostics/DiagnosticsFactory.cs
@@ -5,38 +5,60 @@ namespace MapTo.Diagnostics;
 [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1118:Parameter should not span multiple lines", Justification = "To improve diagnostics messages readability.")]
 internal static class DiagnosticsFactory
 {
+    /// <summary>
+    /// Additional parameters are provided to the '{0}' property type converter, but the '{1}' method does not have a second parameter of type object[].
+    /// </summary>
     internal static Diagnostic PropertyTypeConverterMethodAdditionalParametersIsMissingWarning(IPropertySymbol property, IMethodSymbol converterMethodSymbol) => Create(
         DiagnosticDescriptors.PropertyTypeConverterMethodAdditionalParametersIsMissingWarning,
         converterMethodSymbol.GetLocation(),
         property.ToDisplayString(),
         converterMethodSymbol.Name);
 
+    /// <summary>
+    /// Missing 'partial' keyword on '{0}' class.
+    /// </summary>
     internal static Diagnostic MissingPartialKeywordOnTargetClassError(Location location, string classTypeDisplayName) => Create(
         DiagnosticDescriptors.MissingPartialKeywordOnTargetClassError,
         location,
         classTypeDisplayName);
 
+    /// <summary>
+    /// Missing constructor on '{0}' class.
+    /// </summary>
     internal static Diagnostic MissingConstructorOnTargetClassError(TypeDeclarationSyntax targetType, string classTypeDisplayName) => Create(
         DiagnosticDescriptors.MissingConstructorOnTargetClassError,
         targetType.GetLocation(),
         classTypeDisplayName);
 
+    /// <summary>
+    /// Cannot create a map for '{0}' property because source and destination types are not implicitly convertible.
+    /// Consider using '{1}' to provide a type converter or ignore the property using '{2}'.
+    /// </summary>
     internal static Diagnostic PropertyTypeConverterRequiredError(ISymbol property) => Create(
         DiagnosticDescriptors.PropertyTypeConverterRequiredError,
         property.GetLocation(),
         property.ToDisplayString());
 
+    /// <summary>
+    /// Unable to find '{0}' method. Make sure a matching static method exists in the '{1}' and it is accessible.
+    /// </summary>
     internal static Diagnostic PropertyTypeConverterMethodNotFoundInTargetClassError(ISymbol property, AttributeData typeConverterAttribute) => Create(
         DiagnosticDescriptors.PropertyTypeConverterMethodNotFoundInTargetClassError,
         typeConverterAttribute.GetFirstConstructorLocation(),
         typeConverterAttribute.ConstructorArguments[0].Value,
         property.ContainingType.ToDisplayString());
 
+    /// <summary>
+    /// The '{0}' method must be static.
+    /// </summary>
     internal static Diagnostic PropertyTypeConverterMethodIsNotStaticError(IMethodSymbol converterMethodSymbol) => Create(
         DiagnosticDescriptors.PropertyTypeConverterMethodIsNotStaticError,
         converterMethodSymbol.GetLocation(),
         converterMethodSymbol.Name);
 
+    /// <summary>
+    /// The '{0}' method return type '{1}' is not compatible with the '{2}' property type '{3}'.
+    /// </summary>
     internal static Diagnostic PropertyTypeConverterMethodReturnTypeCompatibilityError(IPropertySymbol property, IMethodSymbol converterMethodSymbol) => Create(
         DiagnosticDescriptors.PropertyTypeConverterMethodReturnTypeCompatibilityError,
         converterMethodSymbol.GetLocation(),
@@ -45,6 +67,9 @@ internal static class DiagnosticsFactory
         property.ToDisplayString(),
         property.Type.ToDisplayString());
 
+    /// <summary>
+    /// The input parameter type '{0}' of the '{1}' method is not compatible with the '{2}' property type '{3}'.
+    /// </summary>
     internal static Diagnostic PropertyTypeConverterMethodInputTypeCompatibilityError(
         string sourcePropertyName,
         ITypeSymbol sourcePropertyType,
@@ -57,12 +82,18 @@ internal static class DiagnosticsFactory
             sourcePropertyName,
             sourcePropertyType.ToDisplayString());
 
+    /// <summary>
+    /// The additional parameters type '{0}' of the '{1}' method must be an object[].
+    /// </summary>
     internal static Diagnostic PropertyTypeConverterMethodAdditionalParametersTypeCompatibilityError(IMethodSymbol converterMethodSymbol) => Create(
         DiagnosticDescriptors.PropertyTypeConverterMethodAdditionalParametersTypeCompatibilityError,
         converterMethodSymbol.Parameters[1].GetLocation(),
         converterMethodSymbol.Parameters[1].Type.ToDisplayString(),
         converterMethodSymbol.Name);
 
+    /// <summary>
+    /// The property '{0}' is nullable, but the '{1}' method parameter '{2}' is not.
+    /// </summary>
     internal static Diagnostic PropertyTypeConverterMethodInputTypeNullCompatibilityError(string sourcePropertyName, IMethodSymbol converterMethodSymbol) => Create(
         DiagnosticDescriptors.PropertyTypeConverterMethodInputTypeNullCompatibilityError,
         converterMethodSymbol.Parameters[0].GetLocation(),
@@ -70,49 +101,85 @@ internal static class DiagnosticsFactory
         converterMethodSymbol.Name,
         converterMethodSymbol.Parameters[0].Name);
 
+    /// <summary>
+    /// Unable to find a suitable type to map '{0}' property. Consider annotating '{1}' using '{nameof(MapFromAttribute)}'
+    /// or ignore the property using '{nameof(IgnorePropertyAttribute)}'.
+    /// </summary>
     internal static Diagnostic SuitableMappingTypeInNestedPropertyNotFoundError(IPropertySymbol property, ITypeSymbol sourceType) => Create(
         DiagnosticDescriptors.SuitableMappingTypeInNestedPropertyNotFoundError,
         property.GetLocation(),
         property.ToDisplayString(),
         sourceType.ToDisplayString());
 
+    /// <summary>
+    /// Cannot create a map for '{0}' class because it has a self-referencing argument in the constructor.
+    /// </summary>
     internal static Diagnostic SelfReferencingConstructorMappingError(Location location, string classTypeDisplayName) => Create(
         DiagnosticDescriptors.SelfReferencingConstructorMappingError,
         location,
         classTypeDisplayName);
 
+    /// <summary>
+    /// Unable to find '{0}' method. Make sure a matching static method exists and it is accessible.
+    /// </summary>
     internal static Diagnostic BeforeOrAfterMapMethodNotFoundError(AttributeData mapPropertyAttribute, string argumentName) => Create(
         DiagnosticDescriptors.BeforeOrAfterMapMethodNotFoundError,
         mapPropertyAttribute.GetNamedArgumentLocation(argumentName),
         mapPropertyAttribute.GetNamedArgument(argumentName));
 
+    /// <summary>
+    /// The '{0}' method must have either no argument or a single argument assignable to the '{1}'.
+    /// </summary>
     internal static Diagnostic BeforeOrAfterMapMethodInvalidParameterError(AttributeData mapPropertyAttribute, string argumentName, ITypeSymbol sourceType) => Create(
         DiagnosticDescriptors.BeforeOrAfterMapMethodInvalidParameterError,
         mapPropertyAttribute.GetNamedArgumentLocation(argumentName),
         mapPropertyAttribute.GetNamedArgument(argumentName),
         sourceType.ToDisplayString());
 
+    /// <summary>
+    /// The '{0}' method must return void or a type that is assignable to the type '{1}'.
+    /// </summary>
     internal static Diagnostic BeforeOrAfterMapMethodInvalidReturnTypeError(AttributeData mapPropertyAttribute, string argumentName, ITypeSymbol sourceType) => Create(
         DiagnosticDescriptors.BeforeOrAfterMapMethodInvalidReturnTypeError,
         mapPropertyAttribute.GetNamedArgumentLocation(argumentName),
         mapPropertyAttribute.GetNamedArgument(argumentName),
         sourceType.ToDisplayString());
 
+    /// <summary>
+    /// The '{0}' method must return void or a single argument assignable to the type '{1}'.
+    /// </summary>
     internal static Diagnostic BeforeOrAfterMapMethodMissingParameterError(AttributeData mapPropertyAttribute, string argumentName, ITypeSymbol sourceType) => Create(
         DiagnosticDescriptors.BeforeOrAfterMapMethodMissingParameterError,
         mapPropertyAttribute.GetNamedArgumentLocation(argumentName),
         mapPropertyAttribute.GetNamedArgument(argumentName),
         sourceType.ToDisplayString());
 
+    /// <summary>
+    /// The argument passed to the '{0}' method might be null but it is not annotated with nullability annotation.
+    /// </summary>
     internal static Diagnostic BeforeOrAfterMapMethodMissingParameterNullabilityAnnotationError(AttributeData mapPropertyAttribute, string argumentName) => Create(
         DiagnosticDescriptors.BeforeOrAfterMapMethodMissingParameterNullabilityAnnotationError,
         mapPropertyAttribute.GetNamedArgumentLocation(argumentName),
         mapPropertyAttribute.GetNamedArgument(argumentName));
 
+    /// <summary>
+    /// The '{0}' method return type might be null but it is not annotated with nullability annotation.
+    /// </summary>
     internal static Diagnostic BeforeOrAfterMapMethodMissingReturnTypeNullabilityAnnotationError(AttributeData mapPropertyAttribute, string argumentName) => Create(
         DiagnosticDescriptors.BeforeOrAfterMapMethodMissingReturnTypeNullabilityAnnotationError,
         mapPropertyAttribute.GetNamedArgumentLocation(argumentName),
         mapPropertyAttribute.GetNamedArgument(argumentName));
+
+    /// <summary>
+    /// The '{0}' method must have either no argument, a single argument assignable to the '{1}' or two arguments assignable to the '{1}' and '{2}'.
+    /// </summary>
+    internal static Diagnostic AfterMapMethodInvalidParametersError(AttributeData mapPropertyAttribute, string argumentName, ITypeSymbol sourceType, ITypeSymbol targetType) =>
+        Create(
+            DiagnosticDescriptors.AfterMapMethodInvalidParametersError,
+            mapPropertyAttribute.GetNamedArgumentLocation(argumentName),
+            mapPropertyAttribute.GetNamedArgument(argumentName),
+            targetType.ToDisplayString(),
+            sourceType.ToDisplayString());
 
     private static Diagnostic Create(DiagnosticDescriptor descriptor, Location? location, params object?[] messageArgs) =>
         Diagnostic.Create(descriptor, location ?? Location.None, messageArgs);

--- a/src/MapTo/Mappings/MethodMapping.cs
+++ b/src/MapTo/Mappings/MethodMapping.cs
@@ -3,7 +3,7 @@
 internal readonly record struct MethodMapping(
     string ContainingType,
     string MethodName,
-    ImmutableArray<string> Parameter,
+    ImmutableArray<string> Parameters,
     bool ReturnsVoid)
 {
     public string MethodFullName => $"{ContainingType}.{MethodName}";
@@ -11,6 +11,6 @@ internal readonly record struct MethodMapping(
     internal static MethodMapping Create(IMethodSymbol methodSymbol) => new(
         ContainingType: methodSymbol.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
         MethodName: methodSymbol.Name,
-        Parameter: methodSymbol.Parameters.Select(p => p.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)).ToImmutableArray(),
+        Parameters: methodSymbol.Parameters.Select(p => p.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)).ToImmutableArray(),
         ReturnsVoid: methodSymbol.ReturnsVoid);
 }

--- a/test/MapTo.Tests/Extensions/ShouldlyExtensions.cs
+++ b/test/MapTo.Tests/Extensions/ShouldlyExtensions.cs
@@ -118,6 +118,15 @@ internal static partial class ShouldlyExtensions
         Assert.Equal(expectedError.Descriptor.MessageFormat, actualDiagnostics.Descriptor.MessageFormat);
         Assert.Equal(expectedError.Descriptor.Title, actualDiagnostics.Descriptor.Title);
         Assert.Equal(expectedError.Location.ToDisplayString(), actualDiagnostics.Location.ToDisplayString());
+        Assert.Equal(expectedError.GetMessage(), actualDiagnostics.GetMessage());
+
+        var actualMessage = actualDiagnostics.GetMessage();
+        if (actualMessage.Contains("''") || actualMessage.Contains("\"\""))
+        {
+            Assert.Fail($"Expected diagnostic message to be equal but found a difference.{Environment.NewLine}" +
+                        $"Expected:{Environment.NewLine}{expectedError.GetMessage()}{Environment.NewLine}" +
+                        $"Actual:{Environment.NewLine}{actualMessage}");
+        }
     }
 
     internal static void ShouldNotBeSuccessful(this ImmutableArray<Diagnostic> diagnostics, string diagnosticId, string? diagnosticMessage = null)

--- a/test/MapTo.Tests/PropertyTypeConverterTests.cs
+++ b/test/MapTo.Tests/PropertyTypeConverterTests.cs
@@ -180,9 +180,9 @@ public class PropertyTypeConverterTests
         var targetMethodSymbol = (targetSemanticModel.GetDeclaredSymbol(targetClassDeclaration.Members[2]) as IMethodSymbol).ShouldNotBeNull();
 
         diagnostics.ShouldNotBeSuccessful(DiagnosticsFactory.PropertyTypeConverterMethodInputTypeCompatibilityError(
-            sourcePropertySymbol.ToDisplayString(),
-            sourcePropertySymbol.Type,
-            targetMethodSymbol));
+            sourcePropertyName: sourcePropertySymbol.Name,
+            sourcePropertyType: sourcePropertySymbol.Type,
+            converterMethodSymbol: targetMethodSymbol));
     }
 
     [Theory]


### PR DESCRIPTION
The aftermap method can now accept both source and target type parameters and can either be void or return the target type. Once the target type is returned, it will be used to complete the mapping process.

Valid methods are:

```csharp
void CustomAfterMap()
void CustomAfterMap(TargetType target)
void CustomAfterMap(SourceType source, TargetType target)

TargetType CustomAfterMap(TargetType target)
TargetType CustomAfterMap(SourceType source, TargetType target)
```