### PR TITLE
Add enum mapping support

### DIFF
--- a/benchmarks/MapTo.Benchmarks/MapTo.Benchmarks.csproj
+++ b/benchmarks/MapTo.Benchmarks/MapTo.Benchmarks.csproj
@@ -5,7 +5,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <IsPackable>false</IsPackable>
-        <EmitCompilerGeneratedFiles>false</EmitCompilerGeneratedFiles>
+        <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
 
         <MapTo_ReferenceHandling>Disabled</MapTo_ReferenceHandling>
     </PropertyGroup>

--- a/src/MapTo.Abstractions/EnumMappingStrategy.cs
+++ b/src/MapTo.Abstractions/EnumMappingStrategy.cs
@@ -1,0 +1,22 @@
+﻿namespace MapTo;
+
+/// <summary>
+/// Specifies the strategy to use when mapping enum values.
+/// </summary>
+public enum EnumMappingStrategy
+{
+    /// <summary>
+    /// Use the enum's underlying value to map to the target enum. This is the default.
+    /// </summary>
+    ByValue,
+
+    /// <summary>
+    /// Use the enum's name to map to the target enum.
+    /// </summary>
+    ByName,
+
+    /// <summary>
+    /// Use the enum's name to map to the target enum, ignoring case.
+    /// </summary>
+    ByNameCaseInsensitive
+}

--- a/src/MapTo.Abstractions/IgnoreEnumMemberAttribute.cs
+++ b/src/MapTo.Abstractions/IgnoreEnumMemberAttribute.cs
@@ -1,0 +1,25 @@
+﻿namespace MapTo;
+
+/// <summary>
+/// Specifies which enum members to ignore.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Enum | AttributeTargets.Field, Inherited = false, AllowMultiple = true)]
+public class IgnoreEnumMemberAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IgnoreEnumMemberAttribute"/> class.
+    /// </summary>
+    /// <param name="enumMember">The enum member to ignore.</param>
+    public IgnoreEnumMemberAttribute(object? enumMember = null)
+    {
+        if (enumMember is not null)
+        {
+            EnumMember = (Enum)enumMember;
+        }
+    }
+
+    /// <summary>
+    /// Gets the enum member to ignore.
+    /// </summary>
+    public Enum? EnumMember { get; }
+}

--- a/src/MapTo.Abstractions/MapFromAttribute.cs
+++ b/src/MapTo.Abstractions/MapFromAttribute.cs
@@ -59,4 +59,9 @@ public sealed class MapFromAttribute : Attribute
     /// </summary>
     /// <value>The way to handle null properties.</value>
     public NullHandling NullHandling { get; set; } = NullHandling.Auto;
+
+    /// <summary>
+    /// Gets or sets the enum mapping strategy. Defaults to <see cref="EnumMappingStrategy.ByValue" />.
+    /// </summary>
+    public EnumMappingStrategy EnumMappingStrategy { get; set; } = EnumMappingStrategy.ByValue;
 }

--- a/src/MapTo.Abstractions/MapFromAttribute.cs
+++ b/src/MapTo.Abstractions/MapFromAttribute.cs
@@ -5,7 +5,7 @@ namespace MapTo;
 /// <summary>
 /// Specifies the source type to map from.
 /// </summary>
-[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Enum, Inherited = false)]
 public sealed class MapFromAttribute : Attribute
 {
     /// <summary>

--- a/src/MapTo.Abstractions/MapFromAttribute.cs
+++ b/src/MapTo.Abstractions/MapFromAttribute.cs
@@ -64,4 +64,9 @@ public sealed class MapFromAttribute : Attribute
     /// Gets or sets the enum mapping strategy. Defaults to <see cref="EnumMappingStrategy.ByValue" />.
     /// </summary>
     public EnumMappingStrategy EnumMappingStrategy { get; set; } = EnumMappingStrategy.ByValue;
+
+    /// <summary>
+    /// Gets or sets the fallback value to use when the enum value is not found in the target enum.
+    /// </summary>
+    public object? EnumMappingFallbackValue { get; set; }
 }

--- a/src/MapTo.Abstractions/MapFromAttribute.cs
+++ b/src/MapTo.Abstractions/MapFromAttribute.cs
@@ -37,8 +37,8 @@ public sealed class MapFromAttribute : Attribute
     /// <summary>
     /// Gets or sets a value indicating whether to use reference handling.
     /// If not set, MapTo will try to automatically determine whether to use reference handling.
-    /// Set to <see langword="true" /> to force reference handling or <see langword="false" /> to
-    /// force no reference handling.
+    /// Set to <see cref="Configuration.ReferenceHandling.Enabled"/> to force reference handling or
+    /// <see cref="Configuration.ReferenceHandling.Disabled"/> to force no reference handling.
     /// </summary>
     public ReferenceHandling ReferenceHandling { get; set; }
 
@@ -69,4 +69,9 @@ public sealed class MapFromAttribute : Attribute
     /// Gets or sets the fallback value to use when the enum value is not found in the target enum.
     /// </summary>
     public object? EnumMappingFallbackValue { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating how strict the enum mapping should be. Defaults to <see cref="StrictEnumMapping.Off" />.
+    /// </summary>
+    public StrictEnumMapping StrictEnumMapping { get; set; } = StrictEnumMapping.Off;
 }

--- a/src/MapTo.Abstractions/PublicAPI.Shipped.txt
+++ b/src/MapTo.Abstractions/PublicAPI.Shipped.txt
@@ -21,6 +21,8 @@ MapTo.MapFromAttribute.ReferenceHandling.set -> void
 MapTo.MapFromAttribute.SourceType.get -> System.Type!
 MapTo.MapFromAttribute.NullHandling.get -> MapTo.NullHandling
 MapTo.MapFromAttribute.NullHandling.set -> void
+MapTo.MapFromAttribute.EnumMappingStrategy.get -> MapTo.EnumMappingStrategy
+MapTo.MapFromAttribute.EnumMappingStrategy.set -> void
 MapTo.MapPropertyAttribute
 MapTo.MapPropertyAttribute.From.get -> string?
 MapTo.MapPropertyAttribute.From.set -> void
@@ -37,3 +39,7 @@ MapTo.NullHandling.Auto = 0 -> MapTo.NullHandling
 MapTo.NullHandling.SetNull = 1 -> MapTo.NullHandling
 MapTo.NullHandling.SetEmptyCollection = 2 -> MapTo.NullHandling
 MapTo.NullHandling.ThrowException = 3 -> MapTo.NullHandling
+MapTo.EnumMappingStrategy
+MapTo.EnumMappingStrategy.ByValue = 0 -> MapTo.EnumMappingStrategy
+MapTo.EnumMappingStrategy.ByName = 1 -> MapTo.EnumMappingStrategy
+MapTo.EnumMappingStrategy.ByNameCaseInsensitive = 2 -> MapTo.EnumMappingStrategy

--- a/src/MapTo.Abstractions/PublicAPI.Shipped.txt
+++ b/src/MapTo.Abstractions/PublicAPI.Shipped.txt
@@ -52,3 +52,6 @@ MapTo.StrictEnumMapping.Off = 0 -> MapTo.StrictEnumMapping
 MapTo.StrictEnumMapping.SourceOnly = 1 -> MapTo.StrictEnumMapping
 MapTo.StrictEnumMapping.TargetOnly = 2 -> MapTo.StrictEnumMapping
 MapTo.StrictEnumMapping.SourceAndTarget = 3 -> MapTo.StrictEnumMapping
+MapTo.IgnoreEnumMemberAttribute
+MapTo.IgnoreEnumMemberAttribute.EnumMember.get -> System.Enum?
+MapTo.IgnoreEnumMemberAttribute.IgnoreEnumMemberAttribute(object? enumMember = null) -> void

--- a/src/MapTo.Abstractions/PublicAPI.Shipped.txt
+++ b/src/MapTo.Abstractions/PublicAPI.Shipped.txt
@@ -23,6 +23,8 @@ MapTo.MapFromAttribute.NullHandling.get -> MapTo.NullHandling
 MapTo.MapFromAttribute.NullHandling.set -> void
 MapTo.MapFromAttribute.EnumMappingStrategy.get -> MapTo.EnumMappingStrategy
 MapTo.MapFromAttribute.EnumMappingStrategy.set -> void
+MapTo.MapFromAttribute.EnumMappingFallbackValue.get -> object?
+MapTo.MapFromAttribute.EnumMappingFallbackValue.set -> void
 MapTo.MapPropertyAttribute
 MapTo.MapPropertyAttribute.From.get -> string?
 MapTo.MapPropertyAttribute.From.set -> void

--- a/src/MapTo.Abstractions/PublicAPI.Shipped.txt
+++ b/src/MapTo.Abstractions/PublicAPI.Shipped.txt
@@ -25,6 +25,8 @@ MapTo.MapFromAttribute.EnumMappingStrategy.get -> MapTo.EnumMappingStrategy
 MapTo.MapFromAttribute.EnumMappingStrategy.set -> void
 MapTo.MapFromAttribute.EnumMappingFallbackValue.get -> object?
 MapTo.MapFromAttribute.EnumMappingFallbackValue.set -> void
+MapTo.MapFromAttribute.StrictEnumMapping.get -> MapTo.StrictEnumMapping
+MapTo.MapFromAttribute.StrictEnumMapping.set -> void
 MapTo.MapPropertyAttribute
 MapTo.MapPropertyAttribute.From.get -> string?
 MapTo.MapPropertyAttribute.From.set -> void
@@ -45,3 +47,8 @@ MapTo.EnumMappingStrategy
 MapTo.EnumMappingStrategy.ByValue = 0 -> MapTo.EnumMappingStrategy
 MapTo.EnumMappingStrategy.ByName = 1 -> MapTo.EnumMappingStrategy
 MapTo.EnumMappingStrategy.ByNameCaseInsensitive = 2 -> MapTo.EnumMappingStrategy
+MapTo.StrictEnumMapping
+MapTo.StrictEnumMapping.Off = 0 -> MapTo.StrictEnumMapping
+MapTo.StrictEnumMapping.SourceOnly = 1 -> MapTo.StrictEnumMapping
+MapTo.StrictEnumMapping.TargetOnly = 2 -> MapTo.StrictEnumMapping
+MapTo.StrictEnumMapping.SourceAndTarget = 3 -> MapTo.StrictEnumMapping

--- a/src/MapTo.Abstractions/StrictEnumMapping.cs
+++ b/src/MapTo.Abstractions/StrictEnumMapping.cs
@@ -1,0 +1,27 @@
+﻿namespace MapTo;
+
+/// <summary>
+/// Specifies whether to enforce strict enum mapping.
+/// </summary>
+public enum StrictEnumMapping
+{
+    /// <summary>
+    /// Do not enforce strict enum mapping. This is the default.
+    /// </summary>
+    Off,
+
+    /// <summary>
+    /// Enforce all source enum members to be mapped to target enum members.
+    /// </summary>
+    SourceOnly,
+
+    /// <summary>
+    /// Enforce all target enum members to be mapped from source enum members.
+    /// </summary>
+    TargetOnly,
+
+    /// <summary>
+    /// Enforce all source enum members to be mapped to target enum members and all target enum members to be mapped from source enum members.
+    /// </summary>
+    SourceAndTarget
+}

--- a/src/MapTo/AnalyzerReleases.Shipped.md
+++ b/src/MapTo/AnalyzerReleases.Shipped.md
@@ -25,3 +25,5 @@
  MT3018  | Mapping  | Error    | After map method does not have correct number of parameters.
  MT3019  | Mapping  | Error    | The source enum member is not found in the target enum.
  MT3020  | Mapping  | Error    | The target enum member is not found in the source enum.
+ MT3021  | Mapping  | Error    | The 'IgnoreEnumMemberAttributeIgnoreEnumMemberAttribute' cannot have arguments when applied to an enum member.
+ MT3022  | Mapping  | Error    | The 'IgnoreEnumMemberAttributeIgnoreEnumMemberAttribute' must have an argument when applied to an enum or class.

--- a/src/MapTo/AnalyzerReleases.Shipped.md
+++ b/src/MapTo/AnalyzerReleases.Shipped.md
@@ -23,3 +23,5 @@
  MT3016  | Mapping  | Error    | Before or after map method parameter has inconsistent nullability annotation.                    
  MT3017  | Mapping  | Error    | Before or after map method return type has inconsistent nullability annotation.
  MT3018  | Mapping  | Error    | After map method does not have correct number of parameters.
+ MT3019  | Mapping  | Error    | The source enum member is not found in the target enum.
+ MT3020  | Mapping  | Error    | The target enum member is not found in the source enum.

--- a/src/MapTo/CodeAnalysis/AttributeDataExtensions.cs
+++ b/src/MapTo/CodeAnalysis/AttributeDataExtensions.cs
@@ -33,4 +33,7 @@ internal static class AttributeDataExtensions
             arguments[0].Expression.ToString(),
         _ => null
     };
+
+    internal static Location? GetLocation(this AttributeData? symbol) =>
+        symbol?.GetAttributeSyntax()?.GetLocation();
 }

--- a/src/MapTo/Configuration/CodeGeneratorOptions.cs
+++ b/src/MapTo/Configuration/CodeGeneratorOptions.cs
@@ -10,12 +10,14 @@ namespace MapTo.Configuration;
 /// <param name="ReferenceHandling">Indicates whether to use reference handling.</param>
 /// <param name="CopyPrimitiveArrays">Indicates whether to copy object and primitive type arrays into a new array.</param>
 /// <param name="NullHandling">Indicates how to handle null properties.</param>
+/// <param name="EnumMappingStrategy">Indicates the strategy to use when mapping enum values.</param>
 internal readonly record struct CodeGeneratorOptions(
     string MapMethodPrefix = "MapTo",
     string MapExtensionClassSuffix = "MapToExtensions",
     ReferenceHandling ReferenceHandling = ReferenceHandling.Disabled,
     bool CopyPrimitiveArrays = false,
-    NullHandling NullHandling = NullHandling.Auto)
+    NullHandling NullHandling = NullHandling.Auto,
+    EnumMappingStrategy EnumMappingStrategy = EnumMappingStrategy.ByValue)
 {
     /// <summary>
     /// The prefix of the property name in the .editorconfig file.
@@ -36,6 +38,7 @@ internal readonly record struct CodeGeneratorOptions(
             MapExtensionClassSuffix: provider.GlobalOptions.GetOption(nameof(MapExtensionClassSuffix), "MapToExtensions"),
             ReferenceHandling: provider.GlobalOptions.GetOption<ReferenceHandling>(nameof(ReferenceHandling)),
             CopyPrimitiveArrays: provider.GlobalOptions.GetOption(nameof(CopyPrimitiveArrays), false),
-            NullHandling: provider.GlobalOptions.GetOption<NullHandling>(nameof(NullHandling)));
+            NullHandling: provider.GlobalOptions.GetOption<NullHandling>(nameof(NullHandling)),
+            EnumMappingStrategy: provider.GlobalOptions.GetOption(nameof(EnumMappingStrategy), EnumMappingStrategy.ByValue));
     }
 }

--- a/src/MapTo/Configuration/CodeGeneratorOptions.cs
+++ b/src/MapTo/Configuration/CodeGeneratorOptions.cs
@@ -11,13 +11,15 @@ namespace MapTo.Configuration;
 /// <param name="CopyPrimitiveArrays">Indicates whether to copy object and primitive type arrays into a new array.</param>
 /// <param name="NullHandling">Indicates how to handle null properties.</param>
 /// <param name="EnumMappingStrategy">Indicates the strategy to use when mapping enum values.</param>
+/// <param name="StrictEnumMapping">Indicates how strict the enum mapping should be.</param>
 internal readonly record struct CodeGeneratorOptions(
     string MapMethodPrefix = "MapTo",
     string MapExtensionClassSuffix = "MapToExtensions",
     ReferenceHandling ReferenceHandling = ReferenceHandling.Disabled,
     bool CopyPrimitiveArrays = false,
     NullHandling NullHandling = NullHandling.Auto,
-    EnumMappingStrategy EnumMappingStrategy = EnumMappingStrategy.ByValue)
+    EnumMappingStrategy EnumMappingStrategy = EnumMappingStrategy.ByValue,
+    StrictEnumMapping StrictEnumMapping = StrictEnumMapping.Off)
 {
     /// <summary>
     /// The prefix of the property name in the .editorconfig file.
@@ -39,6 +41,7 @@ internal readonly record struct CodeGeneratorOptions(
             ReferenceHandling: provider.GlobalOptions.GetOption<ReferenceHandling>(nameof(ReferenceHandling)),
             CopyPrimitiveArrays: provider.GlobalOptions.GetOption(nameof(CopyPrimitiveArrays), false),
             NullHandling: provider.GlobalOptions.GetOption<NullHandling>(nameof(NullHandling)),
-            EnumMappingStrategy: provider.GlobalOptions.GetOption(nameof(EnumMappingStrategy), EnumMappingStrategy.ByValue));
+            EnumMappingStrategy: provider.GlobalOptions.GetOption(nameof(EnumMappingStrategy), EnumMappingStrategy.ByValue),
+            StrictEnumMapping: provider.GlobalOptions.GetOption(nameof(StrictEnumMapping), StrictEnumMapping.Off));
     }
 }

--- a/src/MapTo/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/MapTo/Diagnostics/DiagnosticDescriptors.cs
@@ -247,4 +247,26 @@ internal static class DiagnosticDescriptors
         category: UsageCategory,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
+
+    /// <summary>
+    /// The '{0}' cannot have argument when applied to an enum member.
+    /// </summary>
+    internal static readonly DiagnosticDescriptor IgnoreEnumMemberWithParameterOnMemberError = new DiagnosticDescriptor(
+        id: $"{ErrorId}021",
+        title: string.Empty,
+        messageFormat: "The '{0}' cannot have argument when applied to an enum member",
+        category: UsageCategory,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    /// <summary>
+    /// The '{0}' must have an argument when applied to an enum or class.
+    /// </summary>
+    internal static readonly DiagnosticDescriptor IgnoreEnumMemberWithoutParameterTypeError = new DiagnosticDescriptor(
+        id: $"{ErrorId}022",
+        title: string.Empty,
+        messageFormat: "The '{0}' must have an argument when applied to an enum or class",
+        category: UsageCategory,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
 }

--- a/src/MapTo/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/MapTo/Diagnostics/DiagnosticDescriptors.cs
@@ -225,4 +225,26 @@ internal static class DiagnosticDescriptors
         category: UsageCategory,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
+
+    /// <summary>
+    /// The '{0}' enum member is not defined in the target enum '{1}'.
+    /// </summary>
+    internal static readonly DiagnosticDescriptor StringEnumMappingSourceOnlyError = new DiagnosticDescriptor(
+        id: $"{ErrorId}019",
+        title: string.Empty,
+        messageFormat: "The '{0}' enum member is not defined in the target enum '{1}'",
+        category: UsageCategory,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    /// <summary>
+    /// The '{0}' enum member is not defined in the source enum '{1}'.
+    /// </summary>
+    internal static readonly DiagnosticDescriptor StringEnumMappingTargetOnlyError = new DiagnosticDescriptor(
+        id: $"{ErrorId}020",
+        title: string.Empty,
+        messageFormat: "The '{0}' enum member is not defined in the source enum '{1}'",
+        category: UsageCategory,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
 }

--- a/src/MapTo/Diagnostics/DiagnosticsFactory.cs
+++ b/src/MapTo/Diagnostics/DiagnosticsFactory.cs
@@ -199,6 +199,22 @@ internal static class DiagnosticsFactory
         missingEnumMember.ToDisplayString(),
         sourceEnumType.ToDisplayString());
 
+    /// <summary>
+    /// The '{0}' cannot have argument when applied to an enum member.
+    /// </summary>
+    internal static Diagnostic IgnoreEnumMemberWithParameterOnMemberError(AttributeData enumMemberAttribute, ITypeSymbol ignoreEnumMemberAttributeSymbol) => Create(
+        DiagnosticDescriptors.IgnoreEnumMemberWithParameterOnMemberError,
+        enumMemberAttribute.GetLocation(),
+        ignoreEnumMemberAttributeSymbol.ToDisplayString());
+
+    /// <summary>
+    /// The '{0}' must have an argument when applied to an enum or class.
+    /// </summary>
+    internal static Diagnostic IgnoreEnumMemberWithoutParameterTypeError(AttributeData enumMemberAttribute, ITypeSymbol ignoreEnumMemberAttributeSymbol) => Create(
+        DiagnosticDescriptors.IgnoreEnumMemberWithoutParameterTypeError,
+        enumMemberAttribute.GetLocation(),
+        ignoreEnumMemberAttributeSymbol.ToDisplayString());
+
     private static Diagnostic Create(DiagnosticDescriptor descriptor, Location? location, params object?[] messageArgs) =>
         Diagnostic.Create(descriptor, location ?? Location.None, messageArgs);
 

--- a/src/MapTo/Diagnostics/DiagnosticsFactory.cs
+++ b/src/MapTo/Diagnostics/DiagnosticsFactory.cs
@@ -181,6 +181,24 @@ internal static class DiagnosticsFactory
             targetType.ToDisplayString(),
             sourceType.ToDisplayString());
 
+    /// <summary>
+    /// The '{0}' enum member is not defined in the target enum '{1}'.
+    /// </summary>
+    internal static Diagnostic StringEnumMappingSourceOnlyError(IFieldSymbol missingEnumMember, ITypeSymbol targetEnumType) => Create(
+        DiagnosticDescriptors.StringEnumMappingSourceOnlyError,
+        targetEnumType.GetLocation(),
+        missingEnumMember.ToDisplayString(),
+        targetEnumType.ToDisplayString());
+
+    /// <summary>
+    /// The '{0}' enum member is not defined in the source enum '{1}'.
+    /// </summary>
+    internal static Diagnostic StringEnumMappingTargetOnlyError(IFieldSymbol missingEnumMember, ITypeSymbol sourceEnumType) => Create(
+        DiagnosticDescriptors.StringEnumMappingTargetOnlyError,
+        missingEnumMember.GetLocation(),
+        missingEnumMember.ToDisplayString(),
+        sourceEnumType.ToDisplayString());
+
     private static Diagnostic Create(DiagnosticDescriptor descriptor, Location? location, params object?[] messageArgs) =>
         Diagnostic.Create(descriptor, location ?? Location.None, messageArgs);
 

--- a/src/MapTo/Generators/ExtensionClassGenerator.cs
+++ b/src/MapTo/Generators/ExtensionClassGenerator.cs
@@ -103,7 +103,7 @@ internal static class ExtensionClassGeneratorExtensions
 
             foreach (var member in property.TypeConverter.EnumMapping.Mappings)
             {
-                writer.Write("global::").Write(member.Key).Write(" => ").Write("global::").Write(member.Value).WriteLine(",");
+                writer.Write("global::").Write(member.Source).Write(" => ").Write("global::").Write(member.Target).WriteLine(",");
             }
 
             writer

--- a/src/MapTo/Generators/ExtensionClassGenerator.cs
+++ b/src/MapTo/Generators/ExtensionClassGenerator.cs
@@ -106,10 +106,19 @@ internal static class ExtensionClassGeneratorExtensions
                 writer.Write("global::").Write(member.Source).Write(" => ").Write("global::").Write(member.Target).WriteLine(",");
             }
 
+            if (property.TypeConverter.EnumMapping.FallBackValue is not null)
+            {
+                writer.Write("_ => ").Write("global::").WriteLine(property.TypeConverter.EnumMapping.FallBackValue);
+            }
+            else
+            {
+                writer
+                    .Write("_ => ")
+                    .WriteThrowArgumentOutOfRangeException("source", $"\"Unable to map enum value '{property.SourceType.QualifiedName}' to '{property.Type.QualifiedName}'.\"")
+                    .WriteLineIndented();
+            }
+
             writer
-                .Write("_ => ")
-                .WriteThrowArgumentOutOfRangeException("source", $"\"Unable to map enum value '{property.SourceType.QualifiedName}' to '{property.Type.QualifiedName}'.\"")
-                .WriteLineIndented()
                 .WriteClosingBracket(false)
                 .WriteLine(";")
                 .WriteClosingBracket(); // Method closing bracket

--- a/src/MapTo/Generators/ExtensionClassGenerator.cs
+++ b/src/MapTo/Generators/ExtensionClassGenerator.cs
@@ -77,6 +77,7 @@ internal static class ExtensionClassGeneratorExtensions
     internal static CodeWriter WriteMapEnumMethods(this CodeWriter writer, TargetMapping mapping)
     {
         var properties = mapping.Properties
+            .Union(mapping.Constructor.Parameters.Select(p => p.Property))
             .Where(p => p is { SourceType.IsEnum: true, TypeConverter: { IsMapToExtensionMethod: false, EnumMapping.Strategy: not EnumMappingStrategy.ByValue } })
             .GroupBy(p => p.SourceType)
             .Select(g => g.First());

--- a/src/MapTo/Generators/Handlers/TypeConverterPropertyMappingGenerator.cs
+++ b/src/MapTo/Generators/Handlers/TypeConverterPropertyMappingGenerator.cs
@@ -38,6 +38,10 @@ internal sealed class TypeConverterPropertyMappingGenerator : PropertyMappingGen
 
                 break;
 
+            case { TypeConverter: { IsMapToExtensionMethod: false, EnumMapping.Strategy: EnumMappingStrategy.ByValue } }:
+                writer.Write(targetInstanceName).Write(".").Write(property.Name).Write(" = (").Write(property.TypeName).Write(")").Write(parameterName).WriteLine(";");
+                break;
+
             default:
                 writer.Write(targetInstanceName).Write(".").Write(property.Name).Write(" = ").Wrap(Map(writer, property, parameterName, referenceHandlerName)).WriteLine(";");
                 break;

--- a/src/MapTo/Generators/Handlers/TypeConverterPropertyMappingGenerator.cs
+++ b/src/MapTo/Generators/Handlers/TypeConverterPropertyMappingGenerator.cs
@@ -38,7 +38,7 @@ internal sealed class TypeConverterPropertyMappingGenerator : PropertyMappingGen
 
                 break;
 
-            case { TypeConverter: { IsMapToExtensionMethod: false, EnumMapping.Strategy: EnumMappingStrategy.ByValue } }:
+            case { TypeConverter: { IsMapToExtensionMethod: false, EnumMapping: { IsNull: false, Strategy: EnumMappingStrategy.ByValue } } }:
                 writer.Write(targetInstanceName).Write(".").Write(property.Name).Write(" = (").Write(property.TypeName).Write(")").Write(parameterName).WriteLine(";");
                 break;
 
@@ -58,6 +58,8 @@ internal sealed class TypeConverterPropertyMappingGenerator : PropertyMappingGen
         {
             { HasParameter: true } => writer
                 .Write(typeConverter.MethodFullName).Write("(").Write(parameterName).Write(", ").Write(typeConverter.Parameter).Write(")"),
+            { HasParameter: false, IsMapToExtensionMethod: false, EnumMapping: { IsNull: false, Strategy: EnumMappingStrategy.ByValue } } => writer
+                .Write("(").Write(property.TypeName).Write(")").Write(parameterName),
             { HasParameter: false, ReferenceHandling: false } => writer
                 .Write(typeConverter.MethodFullName).Write("(").Write(parameterName).Write(")"),
             { HasParameter: false, ReferenceHandling: true } => writer

--- a/src/MapTo/KnownTypes.cs
+++ b/src/MapTo/KnownTypes.cs
@@ -11,6 +11,7 @@ internal record KnownTypes(
     internal const string NotNullIfNotNullAttributeFullName = "System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute";
     internal const string CompilerGeneratedAttributeFullName = "System.Runtime.CompilerServices.CompilerGeneratedAttribute";
     internal const string ArgumentNullException = "System.ArgumentNullException";
+    internal const string ArgumentOutOfRangeException = "System.ArgumentOutOfRangeException";
     internal const string GenericList = "System.Collections.Generic.List";
     internal const string Array = "System.Array";
     internal const string LinqEnumerable = "System.Linq.Enumerable";

--- a/src/MapTo/KnownTypes.cs
+++ b/src/MapTo/KnownTypes.cs
@@ -6,7 +6,8 @@ internal record KnownTypes(
     INamedTypeSymbol MapPropertyAttributeTypeSymbol,
     INamedTypeSymbol MapConstructorAttributeTypeSymbol,
     INamedTypeSymbol PropertyTypeConverterAttributeTypeSymbol,
-    INamedTypeSymbol CompilerGeneratedAttributeTypeSymbol)
+    INamedTypeSymbol CompilerGeneratedAttributeTypeSymbol,
+    INamedTypeSymbol IgnoreEnumMemberAttributeTypeSymbol)
 {
     internal const string NotNullIfNotNullAttributeFullName = "System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute";
     internal const string CompilerGeneratedAttributeFullName = "System.Runtime.CompilerServices.CompilerGeneratedAttribute";
@@ -22,5 +23,6 @@ internal record KnownTypes(
         MapPropertyAttributeTypeSymbol: compilation.GetTypeByMetadataNameOrThrow<MapPropertyAttribute>(),
         MapConstructorAttributeTypeSymbol: compilation.GetTypeByMetadataNameOrThrow<MapConstructorAttribute>(),
         PropertyTypeConverterAttributeTypeSymbol: compilation.GetTypeByMetadataNameOrThrow<PropertyTypeConverterAttribute>(),
-        CompilerGeneratedAttributeTypeSymbol: compilation.GetTypeByMetadataNameOrThrow(CompilerGeneratedAttributeFullName));
+        CompilerGeneratedAttributeTypeSymbol: compilation.GetTypeByMetadataNameOrThrow(CompilerGeneratedAttributeFullName),
+        IgnoreEnumMemberAttributeTypeSymbol: compilation.GetTypeByMetadataNameOrThrow<IgnoreEnumMemberAttribute>());
 }

--- a/src/MapTo/Mappings/Handlers/ArrayTypeConverterResolver.cs
+++ b/src/MapTo/Mappings/Handlers/ArrayTypeConverterResolver.cs
@@ -1,0 +1,33 @@
+﻿namespace MapTo.Mappings.Handlers;
+
+internal class ArrayTypeConverterResolver : ITypeConverterResolver
+{
+    /// <inheritdoc />
+    public ResolverResult<TypeConverterMapping> Get(MappingContext context, IPropertySymbol property, SourceProperty sourceProperty)
+    {
+        if (property.Type.IsPrimitiveType() || property.Type is not IArrayTypeSymbol { ElementType: INamedTypeSymbol arrayNamedTypeSymbol })
+        {
+            return ResolverResult.Undetermined<TypeConverterMapping>();
+        }
+
+        var mapFromAttribute = arrayNamedTypeSymbol.GetAttribute(context.KnownTypes.MapFromAttributeTypeSymbol);
+        var propertyTypeName = arrayNamedTypeSymbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+        var mappedSourcePropertyType = mapFromAttribute?.ConstructorArguments.First().Value as INamedTypeSymbol ?? arrayNamedTypeSymbol;
+        var methodPrefix = context.CodeGeneratorOptions.MapMethodPrefix;
+
+        return new TypeConverterMapping(
+            ContainingType: mappedSourcePropertyType.ToExtensionClassName(context.CodeGeneratorOptions),
+            MethodName: mappedSourcePropertyType.IsPrimitiveType() ? $"{methodPrefix}{mappedSourcePropertyType.Name}" : $"{methodPrefix}{propertyTypeName}",
+            Parameter: null,
+            Type: property.Type.ToTypeMapping(),
+            IsMapToExtensionMethod: mapFromAttribute is not null,
+            UsingDirectives: ImmutableArray.Create("global::System.Linq"),
+            ReferenceHandling: context.CodeGeneratorOptions.ReferenceHandling switch
+            {
+                ReferenceHandling.Disabled => false,
+                ReferenceHandling.Enabled => true,
+                ReferenceHandling.Auto when mappedSourcePropertyType.HasNonPrimitiveProperties() => true,
+                _ => false
+            });
+    }
+}

--- a/src/MapTo/Mappings/Handlers/EnumTypeConverterResolver.cs
+++ b/src/MapTo/Mappings/Handlers/EnumTypeConverterResolver.cs
@@ -13,7 +13,7 @@ internal class EnumTypeConverterResolver : ITypeConverterResolver
         var methodPrefix = context.CodeGeneratorOptions.MapMethodPrefix;
         var mapFromAttribute = GetEffectiveMapFromAttribute(context, property);
         var enumMappingStrategy = GetEnumMappingStrategy(context, mapFromAttribute);
-        var memberMappings = GetMemberMappings(property.Type, sourceProperty.TypeSymbol, mapFromAttribute, enumMappingStrategy);
+        var memberMappings = GetMemberMappings(context, property, sourceProperty, enumMappingStrategy);
         if (memberMappings.IsFailure)
         {
             return memberMappings.Error;
@@ -47,16 +47,24 @@ internal class EnumTypeConverterResolver : ITypeConverterResolver
     }
 
     private static ResolverResult<ImmutableArray<EnumMemberMapping>> GetMemberMappings(
-        ITypeSymbol enumTypeSymbol,
-        ITypeSymbol sourceEnumTypeSymbol,
-        AttributeData? mapFromAttribute,
+        MappingContext context,
+        IPropertySymbol property,
+        SourceProperty sourceProperty,
         EnumMappingStrategy enumMappingStrategy)
     {
+        // GetMemberMappings(context.KnownTypes, property.Type, sourceProperty.TypeSymbol, mapFromAttribute, enumMappingStrategy);
+        var enumTypeSymbol = property.Type;
+        var sourceEnumTypeSymbol = sourceProperty.TypeSymbol;
         var members = enumTypeSymbol.GetMembers().OfType<IFieldSymbol>().Where(m => m.HasConstantValue).OrderBy(m => m.ConstantValue).ToArray();
         var sourceMembers = sourceEnumTypeSymbol.GetMembers().OfType<IFieldSymbol>().Where(m => m.HasConstantValue).ToArray();
         var stringComparison = enumMappingStrategy is EnumMappingStrategy.ByNameCaseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
 
-        if (!VerifyStrictMappingsConditions(mapFromAttribute, sourceEnumTypeSymbol, sourceMembers, enumTypeSymbol, members, enumMappingStrategy, out var error))
+        if (!VerifyIgnoreEnumMemberAttributeUsage(context, property, sourceProperty, enumMappingStrategy, out var error))
+        {
+            return error;
+        }
+
+        if (!VerifyStrictMappingsConditions(context, property, sourceProperty, enumMappingStrategy, out error))
         {
             return error;
         }
@@ -80,16 +88,55 @@ internal class EnumTypeConverterResolver : ITypeConverterResolver
         return builder.ToImmutable();
     }
 
-    private static bool VerifyStrictMappingsConditions(
-        AttributeData? mapFromAttribute,
-        ITypeSymbol sourceEnumTypeSymbol,
-        IFieldSymbol[] sourceMembers,
-        ITypeSymbol targetEnumTypeSymbol,
-        IFieldSymbol[] targetMembers,
+    private static bool VerifyIgnoreEnumMemberAttributeUsage(
+        MappingContext context,
+        IPropertySymbol property,
+        SourceProperty sourceProperty,
         EnumMappingStrategy enumMappingStrategy,
         [NotNullWhen(false)] out Diagnostic? error)
     {
         error = null;
+        var knownTypes = context.KnownTypes;
+
+        var faultyAttribute = property.Type.GetMembers().OfType<IFieldSymbol>()
+            .Union(sourceProperty.TypeSymbol.GetMembers().OfType<IFieldSymbol>(), SymbolEqualityComparer.Default)
+            .Where(m => m is not null)
+            .SelectMany(m => m!.GetAttributes(knownTypes.IgnoreEnumMemberAttributeTypeSymbol))
+            .FirstOrDefault(a => a.ConstructorArguments.First().Value is not null);
+
+        if (faultyAttribute is not null)
+        {
+            error = DiagnosticsFactory.IgnoreEnumMemberWithParameterOnMemberError(faultyAttribute, knownTypes.IgnoreEnumMemberAttributeTypeSymbol);
+            return false;
+        }
+
+        faultyAttribute = property.Type.GetAttributes(knownTypes.IgnoreEnumMemberAttributeTypeSymbol)
+            .Union(property.ContainingType.GetAttributes(knownTypes.IgnoreEnumMemberAttributeTypeSymbol))
+            .Union(sourceProperty.TypeSymbol.GetAttributes(knownTypes.IgnoreEnumMemberAttributeTypeSymbol))
+            .FirstOrDefault(a => a.ConstructorArguments.First().Value is null);
+
+        if (faultyAttribute is not null)
+        {
+            error = DiagnosticsFactory.IgnoreEnumMemberWithoutParameterTypeError(faultyAttribute, knownTypes.IgnoreEnumMemberAttributeTypeSymbol);
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool VerifyStrictMappingsConditions(
+        MappingContext context,
+        IPropertySymbol property,
+        SourceProperty sourceProperty,
+        EnumMappingStrategy enumMappingStrategy,
+        [NotNullWhen(false)] out Diagnostic? error)
+    {
+        error = null;
+        var knownTypes = context.KnownTypes;
+        var mapFromAttribute = context.MapFromAttributeData;
+        var targetEnumTypeSymbol = property.Type;
+        var sourceEnumTypeSymbol = sourceProperty.TypeSymbol;
+
         var strictEnumMapping = mapFromAttribute.GetNamedArgument(nameof(MapFromAttribute.StrictEnumMapping), StrictEnumMapping.Off);
         if (strictEnumMapping is StrictEnumMapping.Off)
         {
@@ -97,6 +144,40 @@ internal class EnumTypeConverterResolver : ITypeConverterResolver
         }
 
         var stringComparison = enumMappingStrategy is EnumMappingStrategy.ByNameCaseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        var targetMembers = targetEnumTypeSymbol.GetMembers().OfType<IFieldSymbol>().ToArray();
+        var sourceMembers = sourceEnumTypeSymbol.GetMembers().OfType<IFieldSymbol>().ToArray();
+
+        static IEnumerable<(ITypeSymbol Type, object? Value)> SelectEnumTypeIgnoreMember(AttributeData a) =>
+            a.ConstructorArguments.Select(c => (Type: c.Type!, c.Value));
+
+        (ITypeSymbol Type, object? Value) SelectIgnoredEnumMember(IFieldSymbol m) =>
+            (m.Type, Value: m.GetAttribute(knownTypes.IgnoreEnumMemberAttributeTypeSymbol)?.ConstructorArguments.Single().Value ?? m.ConstantValue);
+
+        var ignoredMembers = property.ContainingType
+            .GetAttributes(knownTypes.IgnoreEnumMemberAttributeTypeSymbol)
+            .SelectMany(SelectEnumTypeIgnoreMember)
+            .Union(targetMembers
+                .Where(m => m.HasAttribute(knownTypes.IgnoreEnumMemberAttributeTypeSymbol))
+                .Select(SelectIgnoredEnumMember))
+            .Union(sourceMembers
+                .Where(m => m.HasAttribute(knownTypes.IgnoreEnumMemberAttributeTypeSymbol))
+                .Select(SelectIgnoredEnumMember))
+            .Union(targetEnumTypeSymbol
+                .GetAttributes(knownTypes.IgnoreEnumMemberAttributeTypeSymbol)
+                .SelectMany(SelectEnumTypeIgnoreMember))
+            .Union(sourceEnumTypeSymbol
+                .GetAttributes(knownTypes.IgnoreEnumMemberAttributeTypeSymbol)
+                .SelectMany(SelectEnumTypeIgnoreMember))
+            .Where(m => m.Value is not null)
+            .ToArray();
+
+        targetMembers = targetMembers
+            .Where(m => !ignoredMembers.Any(i => SymbolEqualityComparer.Default.Equals(i.Type, m.ContainingType) && Equals(i.Value, m.ConstantValue)))
+            .ToArray();
+
+        sourceMembers = sourceMembers
+            .Where(m => !ignoredMembers.Any(i => SymbolEqualityComparer.Default.Equals(i.Type, m.ContainingType) && Equals(i.Value, m.ConstantValue)))
+            .ToArray();
 
         if (strictEnumMapping is not StrictEnumMapping.TargetOnly && sourceMembers.Length > targetMembers.Length)
         {

--- a/src/MapTo/Mappings/Handlers/EnumTypeConverterResolver.cs
+++ b/src/MapTo/Mappings/Handlers/EnumTypeConverterResolver.cs
@@ -1,0 +1,58 @@
+﻿namespace MapTo.Mappings.Handlers;
+
+internal class EnumTypeConverterResolver : ITypeConverterResolver
+{
+    /// <inheritdoc />
+    public ResolverResult<TypeConverterMapping> Get(MappingContext context, IPropertySymbol property, SourceProperty sourceProperty)
+    {
+        if (property.Type.TypeKind is not TypeKind.Enum)
+        {
+            return ResolverResult.Undetermined<TypeConverterMapping>();
+        }
+
+        var methodPrefix = context.CodeGeneratorOptions.MapMethodPrefix;
+        var enumMappingStrategy = GetEnumMappingStrategy(context, property);
+
+        return new TypeConverterMapping(
+            ContainingType: string.Empty,
+            MethodName: $"{methodPrefix}{sourceProperty.TypeSymbol.Name}",
+            Type: property.Type.ToTypeMapping(),
+            EnumMapping: new EnumTypeConverterMapping(
+                Strategy: enumMappingStrategy,
+                Mappings: GetMemberMappings(property.Type, sourceProperty.TypeSymbol, enumMappingStrategy)));
+    }
+
+    private static EnumMappingStrategy GetEnumMappingStrategy(MappingContext context, IPropertySymbol property)
+    {
+        // NB: Check for the mapping strategy in order of precedence.
+        // Property Type > Property > Containing Type > Fall back to code generator options.
+        var mapFromAttribute = property.Type.GetAttribute(context.KnownTypes.MapFromAttributeTypeSymbol)
+                               ?? property.ContainingType.GetAttribute(context.KnownTypes.MapFromAttributeTypeSymbol);
+
+        return mapFromAttribute.GetNamedArgument(nameof(MapFromAttribute.EnumMappingStrategy), context.CodeGeneratorOptions.EnumMappingStrategy);
+    }
+
+    private static ImmutableDictionary<string, string> GetMemberMappings(ITypeSymbol enumTypeSymbol, ITypeSymbol sourceEnumTypeSymbol, EnumMappingStrategy enumMappingStrategy)
+    {
+        if (enumMappingStrategy is EnumMappingStrategy.ByValue)
+        {
+            return ImmutableDictionary<string, string>.Empty;
+        }
+
+        var builder = ImmutableDictionary.CreateBuilder<string, string>(StringComparer.Ordinal);
+        var members = enumTypeSymbol.GetMembers().OfType<IFieldSymbol>().Where(m => m.HasConstantValue).OrderBy(m => m.ConstantValue);
+        var sourceMembers = sourceEnumTypeSymbol.GetMembers().OfType<IFieldSymbol>().Where(m => m.HasConstantValue).ToArray();
+        var stringComparison = enumMappingStrategy is EnumMappingStrategy.ByNameCaseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+        foreach (var member in members)
+        {
+            var sourceMember = sourceMembers.FirstOrDefault(m => m.Name.Equals(member.Name, stringComparison));
+            if (sourceMember is not null)
+            {
+                builder.Add(sourceMember.ToDisplayString(), member.ToDisplayString());
+            }
+        }
+
+        return builder.ToImmutable();
+    }
+}

--- a/src/MapTo/Mappings/Handlers/EnumerableTypeConverterResolver.cs
+++ b/src/MapTo/Mappings/Handlers/EnumerableTypeConverterResolver.cs
@@ -1,0 +1,43 @@
+﻿namespace MapTo.Mappings.Handlers;
+
+internal class EnumerableTypeConverterResolver : ITypeConverterResolver
+{
+    /// <inheritdoc />
+    public ResolverResult<TypeConverterMapping> Get(MappingContext context, IPropertySymbol property, SourceProperty sourceProperty)
+    {
+        if (property.Type.IsPrimitiveType())
+        {
+            return ResolverResult.Undetermined<TypeConverterMapping>();
+        }
+
+        if (property.Type is not INamedTypeSymbol enumerableTypeSymbol || enumerableTypeSymbol.TypeArguments.IsEmpty)
+        {
+            return DiagnosticsFactory.SuitableMappingTypeInNestedPropertyNotFoundError(property, property.Type);
+        }
+
+        var typeSymbol = enumerableTypeSymbol.TypeArguments.First();
+        var mapFromAttribute = typeSymbol.GetAttribute(context.KnownTypes.MapFromAttributeTypeSymbol);
+        if (mapFromAttribute?.ConstructorArguments.First().Value is not INamedTypeSymbol mappedSourcePropertyType)
+        {
+            return DiagnosticsFactory.SuitableMappingTypeInNestedPropertyNotFoundError(property, property.Type);
+        }
+
+        var propertyTypeName = typeSymbol.OriginalDefinition.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+        var methodPrefix = context.CodeGeneratorOptions.MapMethodPrefix;
+
+        return new TypeConverterMapping(
+            mappedSourcePropertyType.ToExtensionClassName(context.CodeGeneratorOptions),
+            mappedSourcePropertyType.IsPrimitiveType() ? $"{methodPrefix}{mappedSourcePropertyType.Name}" : $"{methodPrefix}{propertyTypeName}",
+            property.Type.ToTypeMapping(),
+            null,
+            true,
+            UsingDirectives: ImmutableArray.Create("global::System.Linq"),
+            ReferenceHandling: context.CodeGeneratorOptions.ReferenceHandling switch
+            {
+                ReferenceHandling.Disabled => false,
+                ReferenceHandling.Enabled => true,
+                ReferenceHandling.Auto when mappedSourcePropertyType.HasNonPrimitiveProperties() => true,
+                _ => false
+            });
+    }
+}

--- a/src/MapTo/Mappings/Handlers/ExplicitTypeConverterResolver.cs
+++ b/src/MapTo/Mappings/Handlers/ExplicitTypeConverterResolver.cs
@@ -1,0 +1,78 @@
+﻿namespace MapTo.Mappings.Handlers;
+
+internal class ExplicitTypeConverterResolver : ITypeConverterResolver
+{
+    /// <inheritdoc />
+    public ResolverResult<TypeConverterMapping> Get(MappingContext context, IPropertySymbol property, SourceProperty sourceProperty)
+    {
+        var converterMethodSymbolResult = GetTypeConverterMethod(context, property, sourceProperty);
+        if (converterMethodSymbolResult.IsFailure)
+        {
+            return ResolverResult.Undetermined<TypeConverterMapping>(converterMethodSymbolResult.Error);
+        }
+
+        var additionalParametersResult = GetAdditionalParameters(context, property, converterMethodSymbolResult.Value);
+        return additionalParametersResult.IsFailure
+            ? ResolverResult.Undetermined<TypeConverterMapping>(additionalParametersResult.Error)
+            : new TypeConverterMapping(converterMethodSymbolResult.Value, additionalParametersResult.Value);
+    }
+
+    private static ResolverResult<TypedConstant> GetAdditionalParameters(MappingContext context, IPropertySymbol property, IMethodSymbol converterMethodSymbol)
+    {
+        var typeConverterAttribute = property.GetAttribute(context.KnownTypes.PropertyTypeConverterAttributeTypeSymbol);
+        var additionalParameters = typeConverterAttribute?.NamedArguments.SingleOrDefault(a => a.Key == nameof(PropertyTypeConverterAttribute.Parameters)).Value;
+
+        if (additionalParameters is null || additionalParameters.Value.IsNull)
+        {
+            return ResolverResult.Undetermined<TypedConstant>();
+        }
+
+        return converterMethodSymbol.Parameters.Length switch
+        {
+            1 => DiagnosticsFactory.PropertyTypeConverterMethodAdditionalParametersIsMissingWarning(property, converterMethodSymbol),
+            2 when !converterMethodSymbol.Parameters[1].Type.IsArrayOf(SpecialType.System_Object) =>
+                DiagnosticsFactory.PropertyTypeConverterMethodAdditionalParametersTypeCompatibilityError(converterMethodSymbol),
+            _ => additionalParameters.Value
+        };
+    }
+
+    private static ResolverResult<IMethodSymbol> GetTypeConverterMethod(MappingContext context, IPropertySymbol property, SourceProperty sourceProperty)
+    {
+        var typeConverterAttribute = property.GetAttribute(context.KnownTypes.PropertyTypeConverterAttributeTypeSymbol);
+        var firstArgument = typeConverterAttribute?.ConstructorArguments.First();
+
+        if (firstArgument?.Value is not string converterMethodName)
+        {
+            return DiagnosticsFactory.PropertyTypeConverterRequiredError(property);
+        }
+
+        var converterMethodSymbol = property.ContainingType.GetMembers(converterMethodName).OfType<IMethodSymbol>().SingleOrDefault();
+        if (converterMethodSymbol is null)
+        {
+            return DiagnosticsFactory.PropertyTypeConverterMethodNotFoundInTargetClassError(property, typeConverterAttribute!);
+        }
+
+        if (!converterMethodSymbol.IsStatic)
+        {
+            return DiagnosticsFactory.PropertyTypeConverterMethodIsNotStaticError(converterMethodSymbol);
+        }
+
+        if (!context.Compilation.HasCompatibleTypes(converterMethodSymbol.ReturnType, property))
+        {
+            return DiagnosticsFactory.PropertyTypeConverterMethodReturnTypeCompatibilityError(property, converterMethodSymbol);
+        }
+
+        if (!context.Compilation.HasCompatibleTypes(converterMethodSymbol.Parameters.First().Type, sourceProperty.TypeSymbol))
+        {
+            return DiagnosticsFactory.PropertyTypeConverterMethodInputTypeCompatibilityError(sourceProperty.Name, sourceProperty.TypeSymbol, converterMethodSymbol);
+        }
+
+        if (sourceProperty.Type.NullableAnnotation is NullableAnnotation.Annotated &&
+            converterMethodSymbol.Parameters.First().NullableAnnotation is NullableAnnotation.NotAnnotated)
+        {
+            return DiagnosticsFactory.PropertyTypeConverterMethodInputTypeNullCompatibilityError(sourceProperty.Name, converterMethodSymbol);
+        }
+
+        return ResolverResult.Success(converterMethodSymbol);
+    }
+}

--- a/src/MapTo/Mappings/Handlers/ITypeConverterResolver.cs
+++ b/src/MapTo/Mappings/Handlers/ITypeConverterResolver.cs
@@ -1,0 +1,6 @@
+﻿namespace MapTo.Mappings.Handlers;
+
+internal interface ITypeConverterResolver
+{
+    ResolverResult<TypeConverterMapping> Get(MappingContext context, IPropertySymbol property, SourceProperty sourceProperty);
+}

--- a/src/MapTo/Mappings/Handlers/ImplicitTypeConverterResolver.cs
+++ b/src/MapTo/Mappings/Handlers/ImplicitTypeConverterResolver.cs
@@ -1,0 +1,19 @@
+﻿namespace MapTo.Mappings.Handlers;
+
+internal class ImplicitTypeConverterResolver : ITypeConverterResolver
+{
+    public ResolverResult<TypeConverterMapping> Get(MappingContext context, IPropertySymbol property, SourceProperty sourceProperty)
+    {
+        if (!property.Type.IsArray() && context.Compilation.HasCompatibleTypes(sourceProperty.TypeSymbol, property))
+        {
+            return ResolverResult.Success<TypeConverterMapping>();
+        }
+
+        if (!context.Compilation.IsNonGenericEnumerable(property.Type) && context.Compilation.IsNonGenericEnumerable(sourceProperty.TypeSymbol))
+        {
+            return DiagnosticsFactory.PropertyTypeConverterRequiredError(property);
+        }
+
+        return ResolverResult.Undetermined<TypeConverterMapping>();
+    }
+}

--- a/src/MapTo/Mappings/Handlers/NestedTypeConverterResolver.cs
+++ b/src/MapTo/Mappings/Handlers/NestedTypeConverterResolver.cs
@@ -3,33 +3,30 @@
 internal class NestedTypeConverterResolver : ITypeConverterResolver
 {
     /// <inheritdoc />
-    public virtual ResolverResult<TypeConverterMapping> Get(MappingContext context, IPropertySymbol property, SourceProperty sourceProperty)
+    public ResolverResult<TypeConverterMapping> Get(MappingContext context, IPropertySymbol property, SourceProperty sourceProperty)
     {
-        var mapFromAttribute = property.Type.GetAttribute(context.KnownTypes.MapFromAttributeTypeSymbol);
-        if (mapFromAttribute is null)
-        {
-            return ResolverResult.Undetermined<TypeConverterMapping>();
-        }
-
-        if (mapFromAttribute.ConstructorArguments.First().Value is not INamedTypeSymbol mappedSourcePropertyType)
-        {
-            return ResolverResult.Undetermined<TypeConverterMapping>();
-        }
-
         var methodPrefix = context.CodeGeneratorOptions.MapMethodPrefix;
-        return new TypeConverterMapping(
-            mappedSourcePropertyType.ToExtensionClassName(context.CodeGeneratorOptions),
-            mappedSourcePropertyType.IsPrimitiveType() ? $"{methodPrefix}{mappedSourcePropertyType.Name}" : $"{methodPrefix}{property.Type.Name}",
-            property.Type.ToTypeMapping(),
-            null,
-            true,
-            UsingDirectives: ImmutableArray.Create("global::System.Linq"),
-            ReferenceHandling: context.CodeGeneratorOptions.ReferenceHandling switch
-            {
-                ReferenceHandling.Disabled => false,
-                ReferenceHandling.Enabled => true,
-                ReferenceHandling.Auto when mappedSourcePropertyType.HasNonPrimitiveProperties() => true,
-                _ => false
-            });
+        var mapFromAttribute = property.Type.GetAttribute(context.KnownTypes.MapFromAttributeTypeSymbol);
+        var mappedSourcePropertyType = mapFromAttribute?.ConstructorArguments.First().Value as INamedTypeSymbol;
+
+        return mappedSourcePropertyType switch
+        {
+            null => ResolverResult.Undetermined<TypeConverterMapping>(),
+            { TypeKind: TypeKind.Enum } => ResolverResult.Undetermined<TypeConverterMapping>(), // Is handled by EnumTypeConverterResolver
+            _ => new TypeConverterMapping(
+                mappedSourcePropertyType.ToExtensionClassName(context.CodeGeneratorOptions),
+                mappedSourcePropertyType.IsPrimitiveType() ? $"{methodPrefix}{mappedSourcePropertyType.Name}" : $"{methodPrefix}{property.Type.Name}",
+                property.Type.ToTypeMapping(),
+                null,
+                true,
+                UsingDirectives: ImmutableArray.Create("global::System.Linq"),
+                ReferenceHandling: context.CodeGeneratorOptions.ReferenceHandling switch
+                {
+                    ReferenceHandling.Disabled => false,
+                    ReferenceHandling.Enabled => true,
+                    ReferenceHandling.Auto when mappedSourcePropertyType.HasNonPrimitiveProperties() => true,
+                    _ => false
+                })
+        };
     }
 }

--- a/src/MapTo/Mappings/Handlers/NestedTypeConverterResolver.cs
+++ b/src/MapTo/Mappings/Handlers/NestedTypeConverterResolver.cs
@@ -1,0 +1,35 @@
+﻿namespace MapTo.Mappings.Handlers;
+
+internal class NestedTypeConverterResolver : ITypeConverterResolver
+{
+    /// <inheritdoc />
+    public virtual ResolverResult<TypeConverterMapping> Get(MappingContext context, IPropertySymbol property, SourceProperty sourceProperty)
+    {
+        var mapFromAttribute = property.Type.GetAttribute(context.KnownTypes.MapFromAttributeTypeSymbol);
+        if (mapFromAttribute is null)
+        {
+            return ResolverResult.Undetermined<TypeConverterMapping>();
+        }
+
+        if (mapFromAttribute.ConstructorArguments.First().Value is not INamedTypeSymbol mappedSourcePropertyType)
+        {
+            return ResolverResult.Undetermined<TypeConverterMapping>();
+        }
+
+        var methodPrefix = context.CodeGeneratorOptions.MapMethodPrefix;
+        return new TypeConverterMapping(
+            mappedSourcePropertyType.ToExtensionClassName(context.CodeGeneratorOptions),
+            mappedSourcePropertyType.IsPrimitiveType() ? $"{methodPrefix}{mappedSourcePropertyType.Name}" : $"{methodPrefix}{property.Type.Name}",
+            property.Type.ToTypeMapping(),
+            null,
+            true,
+            UsingDirectives: ImmutableArray.Create("global::System.Linq"),
+            ReferenceHandling: context.CodeGeneratorOptions.ReferenceHandling switch
+            {
+                ReferenceHandling.Disabled => false,
+                ReferenceHandling.Enabled => true,
+                ReferenceHandling.Auto when mappedSourcePropertyType.HasNonPrimitiveProperties() => true,
+                _ => false
+            });
+    }
+}

--- a/src/MapTo/Mappings/Handlers/NestingTypeConverterResolverExtensions.cs
+++ b/src/MapTo/Mappings/Handlers/NestingTypeConverterResolverExtensions.cs
@@ -1,0 +1,8 @@
+﻿namespace MapTo.Mappings.Handlers;
+
+internal static class NestingTypeConverterResolverExtensions
+{
+    public static string ToExtensionClassName(this INamedTypeSymbol typeSymbol, CodeGeneratorOptions options) => typeSymbol.IsPrimitiveType()
+        ? "System"
+        : $"{typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}{options.MapExtensionClassSuffix}";
+}

--- a/src/MapTo/Mappings/Handlers/ResolverResult.cs
+++ b/src/MapTo/Mappings/Handlers/ResolverResult.cs
@@ -1,0 +1,35 @@
+﻿#pragma warning disable SA1649
+
+namespace MapTo.Mappings.Handlers;
+
+internal enum HandlerResultKind
+{
+    Undetermined,
+    Success,
+    Failure
+}
+
+internal readonly record struct ResolverResult<T>(T Value, Diagnostic? Error, HandlerResultKind Kind)
+{
+    public bool IsSuccess => Kind == HandlerResultKind.Success;
+
+    [MemberNotNullWhen(true, nameof(Error))]
+    public bool IsFailure => Error is not null;
+
+    public bool IsUndetermined => Kind == HandlerResultKind.Undetermined;
+
+    public static implicit operator ResolverResult<T>(T value) => new(value, null, HandlerResultKind.Success);
+
+    public static implicit operator ResolverResult<T>(Diagnostic error) => new(default!, error, HandlerResultKind.Failure);
+}
+
+internal static class ResolverResult
+{
+    public static ResolverResult<T> Failure<T>(Diagnostic? error) => new(default!, error, HandlerResultKind.Failure);
+
+    public static ResolverResult<T> Success<T>(T value) => new(value, null, HandlerResultKind.Success);
+
+    public static ResolverResult<T> Success<T>() => new(default!, null, HandlerResultKind.Success);
+
+    public static ResolverResult<T> Undetermined<T>(Diagnostic? error = null) => new(default!, error, HandlerResultKind.Undetermined);
+}

--- a/src/MapTo/Mappings/Handlers/TypeConverterResolver.cs
+++ b/src/MapTo/Mappings/Handlers/TypeConverterResolver.cs
@@ -1,0 +1,45 @@
+﻿namespace MapTo.Mappings.Handlers;
+
+internal class TypeConverterResolver
+{
+    private static readonly ITypeConverterResolver[] Resolvers =
+    {
+        new ImplicitTypeConverterResolver(),
+        new ExplicitTypeConverterResolver(),
+        new NestedTypeConverterResolver(),
+        new ArrayTypeConverterResolver(),
+        new EnumerableTypeConverterResolver()
+    };
+
+    public static bool TryGet(MappingContext context, IPropertySymbol property, SourceProperty sourceProperty, out TypeConverterMapping converter)
+    {
+        converter = default;
+        Diagnostic? error = null;
+
+        foreach (var resolver in Resolvers)
+        {
+            var result = resolver.Get(context, property, sourceProperty);
+            switch (result.Kind)
+            {
+                case HandlerResultKind.Undetermined:
+                    error ??= result.Error;
+                    break;
+
+                case HandlerResultKind.Success:
+                    converter = result.Value;
+                    return true;
+
+                case HandlerResultKind.Failure:
+                    context.ReportDiagnostic(result.Error!);
+                    return false;
+            }
+        }
+
+        if (error is not null)
+        {
+            context.ReportDiagnostic(error);
+        }
+
+        return false;
+    }
+}

--- a/src/MapTo/Mappings/Handlers/TypeConverterResolver.cs
+++ b/src/MapTo/Mappings/Handlers/TypeConverterResolver.cs
@@ -7,6 +7,7 @@ internal class TypeConverterResolver
         new ImplicitTypeConverterResolver(),
         new ExplicitTypeConverterResolver(),
         new NestedTypeConverterResolver(),
+        new EnumTypeConverterResolver(),
         new ArrayTypeConverterResolver(),
         new EnumerableTypeConverterResolver()
     };

--- a/src/MapTo/Mappings/MappingContext.cs
+++ b/src/MapTo/Mappings/MappingContext.cs
@@ -1,5 +1,4 @@
-﻿using MapTo.Configuration;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
+﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace MapTo.Mappings;
 
@@ -33,6 +32,7 @@ internal readonly record struct MappingContext(
             {
                 CopyPrimitiveArrays = mapFromAttributeData.GetNamedArgument(nameof(MapFromAttribute.CopyPrimitiveArrays), source.Options.CopyPrimitiveArrays),
                 ReferenceHandling = mapFromAttributeData.GetNamedArgument(nameof(MapFromAttribute.ReferenceHandling), source.Options.ReferenceHandling),
+                EnumMappingStrategy = mapFromAttributeData.GetNamedArgument(nameof(MapFromAttribute.EnumMappingStrategy), source.Options.EnumMappingStrategy),
                 NullHandling = mapFromAttributeData.GetNamedArgument(
                     nameof(MapFromAttribute.NullHandling),
                     compilation.Options.NullableContextOptions is NullableContextOptions.Disable && source.Options.NullHandling == NullHandling.Auto

--- a/src/MapTo/Mappings/MappingContext.cs
+++ b/src/MapTo/Mappings/MappingContext.cs
@@ -33,6 +33,7 @@ internal readonly record struct MappingContext(
                 CopyPrimitiveArrays = mapFromAttributeData.GetNamedArgument(nameof(MapFromAttribute.CopyPrimitiveArrays), source.Options.CopyPrimitiveArrays),
                 ReferenceHandling = mapFromAttributeData.GetNamedArgument(nameof(MapFromAttribute.ReferenceHandling), source.Options.ReferenceHandling),
                 EnumMappingStrategy = mapFromAttributeData.GetNamedArgument(nameof(MapFromAttribute.EnumMappingStrategy), source.Options.EnumMappingStrategy),
+                StrictEnumMapping = mapFromAttributeData.GetNamedArgument(nameof(MapFromAttribute.StrictEnumMapping), source.Options.StrictEnumMapping),
                 NullHandling = mapFromAttributeData.GetNamedArgument(
                     nameof(MapFromAttribute.NullHandling),
                     compilation.Options.NullableContextOptions is NullableContextOptions.Disable && source.Options.NullHandling == NullHandling.Auto

--- a/src/MapTo/Mappings/SourceProperty.cs
+++ b/src/MapTo/Mappings/SourceProperty.cs
@@ -1,0 +1,6 @@
+﻿namespace MapTo.Mappings;
+
+internal readonly record struct SourceProperty(ITypeSymbol TypeSymbol, TypeMapping Type, string Name)
+{
+    internal bool NotFound => string.IsNullOrWhiteSpace(Name);
+}

--- a/src/MapTo/Mappings/TypeConverterMapping.cs
+++ b/src/MapTo/Mappings/TypeConverterMapping.cs
@@ -10,7 +10,7 @@ internal readonly record struct TypeConverterMapping(
     bool IsMapToExtensionMethod = false,
     bool ReferenceHandling = false,
     ImmutableArray<string>? UsingDirectives = null,
-    EnumTypeConverterMapping EnumMapping = default)
+    EnumTypeMapping EnumMapping = default)
 {
     public TypeConverterMapping(IMethodSymbol method, TypedConstant parameters)
         : this(
@@ -25,6 +25,6 @@ internal readonly record struct TypeConverterMapping(
     public string MethodFullName => string.IsNullOrEmpty(ContainingType) ? MethodName : $"{ContainingType}.{MethodName}";
 }
 
-internal readonly record struct EnumTypeConverterMapping(
-    EnumMappingStrategy Strategy,
-    ImmutableDictionary<string, string> Mappings);
+internal readonly record struct EnumTypeMapping(EnumMappingStrategy Strategy, ImmutableArray<EnumMemberMapping> Mappings);
+
+internal readonly record struct EnumMemberMapping(string Source, string Target);

--- a/src/MapTo/Mappings/TypeConverterMapping.cs
+++ b/src/MapTo/Mappings/TypeConverterMapping.cs
@@ -5,17 +5,17 @@ namespace MapTo.Mappings;
 internal readonly record struct TypeConverterMapping(
     string ContainingType,
     string MethodName,
-    string? Parameter,
     TypeMapping Type,
+    string? Parameter = null,
     bool IsMapToExtensionMethod = false,
     bool ReferenceHandling = false,
     ImmutableArray<string>? UsingDirectives = null)
 {
-    public TypeConverterMapping(IMethodSymbol method, TypedConstant? parameters)
+    public TypeConverterMapping(IMethodSymbol method, TypedConstant parameters)
         : this(
             ContainingType: method.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
             MethodName: method.Name,
-            Parameter: parameters?.ToSourceCodeString(),
+            Parameter: parameters.IsNull ? null : parameters.ToSourceCodeString(),
             Type: method.ReturnType.ToTypeMapping()) { }
 
     [MemberNotNullWhen(true, nameof(Parameter))]

--- a/src/MapTo/Mappings/TypeConverterMapping.cs
+++ b/src/MapTo/Mappings/TypeConverterMapping.cs
@@ -25,6 +25,6 @@ internal readonly record struct TypeConverterMapping(
     public string MethodFullName => string.IsNullOrEmpty(ContainingType) ? MethodName : $"{ContainingType}.{MethodName}";
 }
 
-internal readonly record struct EnumTypeMapping(EnumMappingStrategy Strategy, ImmutableArray<EnumMemberMapping> Mappings);
+internal readonly record struct EnumTypeMapping(EnumMappingStrategy Strategy, ImmutableArray<EnumMemberMapping> Mappings, string? FallBackValue);
 
 internal readonly record struct EnumMemberMapping(string Source, string Target);

--- a/src/MapTo/Mappings/TypeConverterMapping.cs
+++ b/src/MapTo/Mappings/TypeConverterMapping.cs
@@ -25,6 +25,9 @@ internal readonly record struct TypeConverterMapping(
     public string MethodFullName => string.IsNullOrEmpty(ContainingType) ? MethodName : $"{ContainingType}.{MethodName}";
 }
 
-internal readonly record struct EnumTypeMapping(EnumMappingStrategy Strategy, ImmutableArray<EnumMemberMapping> Mappings, string? FallBackValue);
+internal readonly record struct EnumTypeMapping(EnumMappingStrategy Strategy, ImmutableArray<EnumMemberMapping> Mappings, string? FallBackValue, bool Initialized = true)
+{
+    public bool IsNull => !Initialized;
+}
 
 internal readonly record struct EnumMemberMapping(string Source, string Target);

--- a/src/MapTo/Mappings/TypeConverterMapping.cs
+++ b/src/MapTo/Mappings/TypeConverterMapping.cs
@@ -9,7 +9,8 @@ internal readonly record struct TypeConverterMapping(
     string? Parameter = null,
     bool IsMapToExtensionMethod = false,
     bool ReferenceHandling = false,
-    ImmutableArray<string>? UsingDirectives = null)
+    ImmutableArray<string>? UsingDirectives = null,
+    EnumTypeConverterMapping EnumMapping = default)
 {
     public TypeConverterMapping(IMethodSymbol method, TypedConstant parameters)
         : this(
@@ -21,5 +22,9 @@ internal readonly record struct TypeConverterMapping(
     [MemberNotNullWhen(true, nameof(Parameter))]
     public bool HasParameter => Parameter is not null;
 
-    public string MethodFullName => $"{ContainingType}.{MethodName}";
+    public string MethodFullName => string.IsNullOrEmpty(ContainingType) ? MethodName : $"{ContainingType}.{MethodName}";
 }
+
+internal readonly record struct EnumTypeConverterMapping(
+    EnumMappingStrategy Strategy,
+    ImmutableDictionary<string, string> Mappings);

--- a/src/MapTo/Mappings/TypeMapping.cs
+++ b/src/MapTo/Mappings/TypeMapping.cs
@@ -6,9 +6,11 @@ namespace MapTo.Mappings;
 internal readonly record struct TypeMapping(
     string Name,
     string FullName,
+    string QualifiedName,
     bool IsNullable,
     NullableAnnotation NullableAnnotation,
     bool IsArray,
+    bool IsEnum,
     string ElementTypeName,
     EnumerableType EnumerableType,
     NullableAnnotation ElementTypeNullableAnnotation,
@@ -47,9 +49,11 @@ internal static class TypeMappingExtensions
         var mapping = new TypeMapping(
             Name: typeSymbol.Name,
             FullName: typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+            QualifiedName: typeSymbol.ToDisplayString(),
             IsNullable: typeSymbol.IsReferenceType || typeSymbol.NullableAnnotation is NullableAnnotation.Annotated,
             NullableAnnotation: nullableAnnotation is NullableAnnotation.None ? typeSymbol.NullableAnnotation : nullableAnnotation,
             IsArray: isArray,
+            IsEnum: typeSymbol.TypeKind == TypeKind.Enum,
             ElementTypeName: elementTypeName,
             EnumerableType: enumerableType,
             ElementTypeNullableAnnotation: elementType?.NullableAnnotation ?? NullableAnnotation.None,

--- a/src/MapTo/Usings.cs
+++ b/src/MapTo/Usings.cs
@@ -1,5 +1,7 @@
 ﻿global using System.Collections.Immutable;
 global using System.Diagnostics.CodeAnalysis;
 global using MapTo.CodeAnalysis;
+global using MapTo.Configuration;
+global using MapTo.Diagnostics;
 global using Microsoft.CodeAnalysis;
 global using Microsoft.CodeAnalysis.CSharp;

--- a/test/MapTo.Tests/MapEnumsTests.cs
+++ b/test/MapTo.Tests/MapEnumsTests.cs
@@ -134,4 +134,32 @@ public class MapEnumsTests
             }
             """);
     }
+
+    [Fact]
+    public void When_TargetEnumHasMapFromAttribute_Should_UseItToMap()
+    {
+        // Arrange
+        var builder = ScenarioBuilder.EnumWithMapFromAttribute(EnumMappingStrategy.ByName);
+
+        // Act
+        var (compilation, diagnostics) = builder.Compile();
+
+        // Assert
+        compilation.Dump(_output);
+        diagnostics.ShouldBeSuccessful();
+
+        var targetClass = compilation.GetClassDeclaration("SourceClassMapToExtensions").ShouldNotBeNull();
+        targetClass.ShouldContain(
+            """
+            private static global::MapTo.Tests.TargetEnum MapToSourceEnum(global::MapTo.Tests.SourceEnum source)
+            {
+                return source switch
+                {
+                    global::MapTo.Tests.SourceEnum.Value1 => global::MapTo.Tests.TargetEnum.Value1,
+                    global::MapTo.Tests.SourceEnum.Value2 => global::MapTo.Tests.TargetEnum.Value2,
+                    _ => throw new global::System.ArgumentOutOfRangeException("source", source, "Unable to map enum value 'MapTo.Tests.SourceEnum' to 'MapTo.Tests.TargetEnum'.")
+                };
+            }
+            """);
+    }
 }

--- a/test/MapTo.Tests/MapEnumsTests.cs
+++ b/test/MapTo.Tests/MapEnumsTests.cs
@@ -1,0 +1,137 @@
+﻿namespace MapTo.Tests;
+
+public class MapEnumsTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public MapEnumsTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public void When_TargetClassEnumStrategyIsByName_Should_GenerateEnumMappingMethod()
+    {
+        // Arrange
+        var builder = ScenarioBuilder.SimpleClassWithTwoEnumProperties(enumMappingStrategy: EnumMappingStrategy.ByName);
+
+        // Act
+        var (compilation, diagnostics) = builder.Compile();
+
+        // Assert
+        diagnostics.ShouldBeSuccessful();
+
+        var targetClass = compilation.GetClassDeclaration("SourceClassMapToExtensions").ShouldNotBeNull();
+        targetClass.ShouldContain(
+            """
+            target.Prop1 = MapToSourceEnum(sourceClass.Prop1);
+            target.Prop2 = MapToSourceEnum(sourceClass.Prop2);
+            """);
+
+        targetClass.ShouldContain(
+            """
+            private static global::MapTo.Tests.TargetEnum MapToSourceEnum(global::MapTo.Tests.SourceEnum source)
+            {
+                return source switch
+                {
+                    global::MapTo.Tests.SourceEnum.Value1 => global::MapTo.Tests.TargetEnum.Value1,
+                    global::MapTo.Tests.SourceEnum.Value2 => global::MapTo.Tests.TargetEnum.Value2,
+                    _ => throw new global::System.ArgumentOutOfRangeException("source", source, "Unable to map enum value 'MapTo.Tests.SourceEnum' to 'MapTo.Tests.TargetEnum'.")
+                };
+            }
+            """);
+    }
+
+    [Fact]
+    public void When_TargetClassEnumStrategyIsByValue_Should_GenerateEnumMappingMethod()
+    {
+        // Arrange
+        var builder = ScenarioBuilder.SimpleClassWithTwoEnumProperties(enumMappingStrategy: EnumMappingStrategy.ByValue);
+
+        // Act
+        var (compilation, diagnostics) = builder.Compile();
+
+        // Assert
+        diagnostics.ShouldBeSuccessful();
+
+        var targetClass = compilation.GetClassDeclaration("SourceClassMapToExtensions").ShouldNotBeNull();
+        targetClass.ShouldContain(
+            """
+            target.Prop1 = (global::MapTo.Tests.TargetEnum)sourceClass.Prop1;
+            target.Prop2 = (global::MapTo.Tests.TargetEnum)sourceClass.Prop2;
+            """);
+    }
+
+    [Fact]
+    public void When_TargetEnumNotAnnotated_Should_MapEnumByValue()
+    {
+        // Arrange
+        var builder = ScenarioBuilder.SimpleClassWithTwoEnumProperties(enumMappingStrategy: null);
+
+        // Act
+        var (compilation, diagnostics) = builder.Compile();
+
+        // Assert
+        diagnostics.ShouldBeSuccessful();
+
+        var targetClass = compilation.GetClassDeclaration("SourceClassMapToExtensions").ShouldNotBeNull();
+        targetClass.ShouldContain(
+            """
+            target.Prop1 = (global::MapTo.Tests.TargetEnum)sourceClass.Prop1;
+            target.Prop2 = (global::MapTo.Tests.TargetEnum)sourceClass.Prop2;
+            """);
+    }
+
+    [Fact]
+    public void When_TargetEnumIsByNameCaseSensitive_Should_MapMembersWithSameCasing()
+    {
+        // Arrange
+        var builder = ScenarioBuilder.SimpleClassWithTwoEnumProperties(enumMappingStrategy: EnumMappingStrategy.ByName, lowercaseTargetEnum: true);
+
+        // Act
+        var (compilation, diagnostics) = builder.Compile();
+
+        // Assert
+        diagnostics.ShouldBeSuccessful();
+
+        var targetClass = compilation.GetClassDeclaration("SourceClassMapToExtensions").ShouldNotBeNull();
+        targetClass.ShouldContain(
+            """
+            private static global::MapTo.Tests.TargetEnum MapToSourceEnum(global::MapTo.Tests.SourceEnum source)
+            {
+                return source switch
+                {
+                    global::MapTo.Tests.SourceEnum.Value1 => global::MapTo.Tests.TargetEnum.Value1,
+                    _ => throw new global::System.ArgumentOutOfRangeException("source", source, "Unable to map enum value 'MapTo.Tests.SourceEnum' to 'MapTo.Tests.TargetEnum'.")
+                };
+            }
+            """);
+    }
+
+    [Fact]
+    public void When_TargetEnumIsByNameCaseInsensitive_Should_IgnoreCasing()
+    {
+        // Arrange
+        var builder = ScenarioBuilder.SimpleClassWithTwoEnumProperties(enumMappingStrategy: EnumMappingStrategy.ByNameCaseInsensitive, lowercaseTargetEnum: true);
+
+        // Act
+        var (compilation, diagnostics) = builder.Compile();
+
+        // Assert
+        diagnostics.ShouldBeSuccessful();
+
+        var targetClass = compilation.GetClassDeclaration("SourceClassMapToExtensions").ShouldNotBeNull();
+        targetClass.ShouldContain(
+            """
+            private static global::MapTo.Tests.TargetEnum MapToSourceEnum(global::MapTo.Tests.SourceEnum source)
+            {
+                return source switch
+                {
+                    global::MapTo.Tests.SourceEnum.Value1 => global::MapTo.Tests.TargetEnum.Value1,
+                    global::MapTo.Tests.SourceEnum.Value2 => global::MapTo.Tests.TargetEnum.value2,
+                    _ => throw new global::System.ArgumentOutOfRangeException("source", source, "Unable to map enum value 'MapTo.Tests.SourceEnum' to 'MapTo.Tests.TargetEnum'.")
+                };
+            }
+            """);
+    }
+}

--- a/test/MapTo.Tests/MapEnumsTests.cs
+++ b/test/MapTo.Tests/MapEnumsTests.cs
@@ -1,4 +1,6 @@
-﻿namespace MapTo.Tests;
+﻿using MapTo.Diagnostics;
+
+namespace MapTo.Tests;
 
 public class MapEnumsTests
 {
@@ -43,7 +45,7 @@ public class MapEnumsTests
     }
 
     [Fact]
-    public void When_TargetClassEnumStrategyIsByValue_Should_GenerateEnumMappingMethod()
+    public void When_TargetClassEnumStrategyIsByValue_Should_NotGenerateEnumMappingMethod()
     {
         // Arrange
         var builder = ScenarioBuilder.SimpleClassWithTwoEnumProperties(enumMappingStrategy: EnumMappingStrategy.ByValue);
@@ -60,6 +62,42 @@ public class MapEnumsTests
             target.Prop1 = (global::MapTo.Tests.TargetEnum)sourceClass.Prop1;
             target.Prop2 = (global::MapTo.Tests.TargetEnum)sourceClass.Prop2;
             """);
+    }
+
+    [Fact]
+    public void When_TargetRecordEnumStrategyIsByValue_Should_NotGenerateEnumMappingMethod()
+    {
+        // Arrange
+        var builder = new TestSourceBuilder();
+        builder.AddFile().WithBody(
+            """
+            public enum SourceEnum
+            {
+                Value1,
+                Value2
+            }
+
+            public enum TargetEnum
+            {
+                Value1,
+                Value2
+            }
+
+            public record SourceClass(SourceEnum Prop1);
+
+            [MapFrom(typeof(SourceClass))]
+            public record TargetClass(TargetEnum Prop1);
+            """);
+
+        // Act
+        var (compilation, diagnostics) = builder.Compile();
+
+        // Assert
+        compilation.Dump(_output);
+        diagnostics.ShouldBeSuccessful();
+
+        var targetClass = compilation.GetClassDeclaration("SourceClassMapToExtensions").ShouldNotBeNull();
+        targetClass.ShouldContain("return new TargetClass((global::MapTo.Tests.TargetEnum)sourceClass.Prop1);");
     }
 
     [Fact]
@@ -102,6 +140,54 @@ public class MapEnumsTests
                 return source switch
                 {
                     global::MapTo.Tests.SourceEnum.Value1 => global::MapTo.Tests.TargetEnum.Value1,
+                    _ => throw new global::System.ArgumentOutOfRangeException("source", source, "Unable to map enum value 'MapTo.Tests.SourceEnum' to 'MapTo.Tests.TargetEnum'.")
+                };
+            }
+            """);
+    }
+
+    [Fact]
+    public void When_TargetRecordEnumStrategyIsByName_Should_GenerateEnumMappingMethod()
+    {
+        // Arrange
+        var builder = new TestSourceBuilder();
+        builder.AddFile().WithBody(
+            """
+            public enum SourceEnum
+            {
+                Value1,
+                Value2,
+                Value3
+            }
+
+            public enum TargetEnum
+            {
+                Value1,
+                Value2
+            }
+
+            public record SourceClass(SourceEnum Prop1);
+
+            [MapFrom(typeof(SourceClass), EnumMappingStrategy = EnumMappingStrategy.ByName)]
+            public record TargetClass(TargetEnum Prop1);
+            """);
+
+        // Act
+        var (compilation, diagnostics) = builder.Compile();
+
+        // Assert
+        diagnostics.ShouldBeSuccessful();
+
+        var targetClass = compilation.GetClassDeclaration("SourceClassMapToExtensions").ShouldNotBeNull();
+        targetClass.ShouldContain("return new TargetClass(MapToSourceEnum(sourceClass.Prop1));");
+        targetClass.ShouldContain(
+            """
+            private static global::MapTo.Tests.TargetEnum MapToSourceEnum(global::MapTo.Tests.SourceEnum source)
+            {
+                return source switch
+                {
+                    global::MapTo.Tests.SourceEnum.Value1 => global::MapTo.Tests.TargetEnum.Value1,
+                    global::MapTo.Tests.SourceEnum.Value2 => global::MapTo.Tests.TargetEnum.Value2,
                     _ => throw new global::System.ArgumentOutOfRangeException("source", source, "Unable to map enum value 'MapTo.Tests.SourceEnum' to 'MapTo.Tests.TargetEnum'.")
                 };
             }
@@ -193,5 +279,227 @@ public class MapEnumsTests
                 };
             }
             """);
+    }
+
+    [Fact]
+    public void StrictEnumMappingIsSourceOnly_When_AllSourceEnumMembersHaveNotMapped_Should_ReportDiagnostics()
+    {
+        // Arrange
+        var builder = new TestSourceBuilder();
+        builder.AddFile().WithBody(
+            """
+            public enum SourceEnum
+            {
+                Value1,
+                Value2,
+                Value3
+            }
+
+            public enum TargetEnum
+            {
+                Value1,
+                Value2
+            }
+
+            public record SourceClass(SourceEnum Prop1);
+
+            [MapFrom(typeof(SourceClass), StrictEnumMapping = StrictEnumMapping.SourceOnly)]
+            public record TargetClass(TargetEnum Prop1);
+            """);
+
+        // Act
+        var (compilation, diagnostics) = builder.Compile();
+
+        // Assert
+        var targetEnumSymbol = compilation.GetTypeByMetadataName("MapTo.Tests.TargetEnum").ShouldNotBeNull();
+        var sourceEnumSymbol = compilation.GetTypeByMetadataName("MapTo.Tests.SourceEnum").ShouldNotBeNull();
+        var missingMember = sourceEnumSymbol.GetMembers().OfType<IFieldSymbol>().First(m => m.Name == "Value3");
+
+        diagnostics.ShouldNotBeSuccessful(
+            DiagnosticsFactory.StringEnumMappingSourceOnlyError(missingMember, targetEnumSymbol),
+            ignoreDiagnosticsIds: new[] { "MT3002" });
+    }
+
+    [Fact]
+    public void StrictEnumMappingIsSourceOnly_When_AllTargetEnumMembersHaveNotMapped_Should_NotReportDiagnostics()
+    {
+        // Arrange
+        var builder = new TestSourceBuilder();
+        builder.AddFile().WithBody(
+            """
+            public enum SourceEnum
+            {
+                Value1,
+                Value2
+            }
+
+            public enum TargetEnum
+            {
+                Value1,
+                Value2,
+                Value3
+            }
+
+            public record SourceClass(SourceEnum Prop1);
+
+            [MapFrom(typeof(SourceClass), StrictEnumMapping = StrictEnumMapping.SourceOnly)]
+            public record TargetClass(TargetEnum Prop1);
+            """);
+
+        // Act
+        var (_, diagnostics) = builder.Compile();
+
+        // Assert
+        diagnostics.ShouldBeSuccessful();
+    }
+
+    [Fact]
+    public void StrictEnumMappingIsTargetOnly_When_AllTargetEnumMembersHaveNotMapped_Should_ReportDiagnostics()
+    {
+        // Arrange
+        var builder = new TestSourceBuilder();
+        builder.AddFile().WithBody(
+            """
+            public enum SourceEnum
+            {
+                Value1,
+                Value2
+            }
+
+            public enum TargetEnum
+            {
+                Value1,
+                Value2,
+                Value3
+            }
+
+            public record SourceClass(SourceEnum Prop1);
+
+            [MapFrom(typeof(SourceClass), StrictEnumMapping = StrictEnumMapping.TargetOnly)]
+            public record TargetClass(TargetEnum Prop1);
+            """);
+
+        // Act
+        var (compilation, diagnostics) = builder.Compile();
+
+        // Assert
+        var targetEnumSymbol = compilation.GetTypeByMetadataName("MapTo.Tests.TargetEnum").ShouldNotBeNull();
+        var sourceEnumSymbol = compilation.GetTypeByMetadataName("MapTo.Tests.SourceEnum").ShouldNotBeNull();
+        var missingMember = targetEnumSymbol.GetMembers().OfType<IFieldSymbol>().First(m => m.Name == "Value3");
+
+        diagnostics.ShouldNotBeSuccessful(
+            DiagnosticsFactory.StringEnumMappingTargetOnlyError(missingMember, sourceEnumSymbol),
+            ignoreDiagnosticsIds: new[] { "MT3002" });
+    }
+
+    [Fact]
+    public void StrictEnumMappingIsTargetOnly_When_AllSourceEnumMembersHaveNotMapped_Should_NotReportDiagnostics()
+    {
+        // Arrange
+        var builder = new TestSourceBuilder();
+        builder.AddFile().WithBody(
+            """
+            public enum SourceEnum
+            {
+                Value1,
+                Value2,
+                Value3
+            }
+
+            public enum TargetEnum
+            {
+                Value1,
+                Value2
+            }
+
+            public record SourceClass(SourceEnum Prop1);
+
+            [MapFrom(typeof(SourceClass), StrictEnumMapping = StrictEnumMapping.TargetOnly)]
+            public record TargetClass(TargetEnum Prop1);
+            """);
+
+        // Act
+        var (_, diagnostics) = builder.Compile();
+
+        // Assert
+        diagnostics.ShouldBeSuccessful();
+    }
+
+    [Fact]
+    public void StrictEnumMappingIsSourceAndTarget_When_AllTargetEnumMembersHaveNotMapped_Should_ReportDiagnostics()
+    {
+        // Arrange
+        var builder = new TestSourceBuilder();
+        builder.AddFile().WithBody(
+            """
+            public enum SourceEnum
+            {
+                Value1,
+                Value2
+            }
+
+            public enum TargetEnum
+            {
+                Value1,
+                Value2,
+                Value3
+            }
+
+            public record SourceClass(SourceEnum Prop1);
+
+            [MapFrom(typeof(SourceClass), StrictEnumMapping = StrictEnumMapping.SourceAndTarget)]
+            public record TargetClass(TargetEnum Prop1);
+            """);
+
+        // Act
+        var (compilation, diagnostics) = builder.Compile();
+
+        // Assert
+        var targetEnumSymbol = compilation.GetTypeByMetadataName("MapTo.Tests.TargetEnum").ShouldNotBeNull();
+        var sourceEnumSymbol = compilation.GetTypeByMetadataName("MapTo.Tests.SourceEnum").ShouldNotBeNull();
+        var missingMember = targetEnumSymbol.GetMembers().OfType<IFieldSymbol>().First(m => m.Name == "Value3");
+
+        diagnostics.ShouldNotBeSuccessful(
+            DiagnosticsFactory.StringEnumMappingTargetOnlyError(missingMember, sourceEnumSymbol),
+            ignoreDiagnosticsIds: new[] { "MT3002" });
+    }
+
+    [Fact]
+    public void StrictEnumMappingIsSourceAndTarget_When_AllSourceEnumMembersHaveNotMapped_Should_ReportDiagnostics()
+    {
+        // Arrange
+        var builder = new TestSourceBuilder();
+        builder.AddFile().WithBody(
+            """
+            public enum SourceEnum
+            {
+                Value1,
+                Value2,
+                Value3
+            }
+
+            public enum TargetEnum
+            {
+                Value1,
+                Value2
+            }
+
+            public record SourceClass(SourceEnum Prop1);
+
+            [MapFrom(typeof(SourceClass), StrictEnumMapping = StrictEnumMapping.SourceAndTarget)]
+            public record TargetClass(TargetEnum Prop1);
+            """);
+
+        // Act
+        var (compilation, diagnostics) = builder.Compile();
+
+        // Assert
+        var targetEnumSymbol = compilation.GetTypeByMetadataName("MapTo.Tests.TargetEnum").ShouldNotBeNull();
+        var sourceEnumSymbol = compilation.GetTypeByMetadataName("MapTo.Tests.SourceEnum").ShouldNotBeNull();
+        var missingMember = sourceEnumSymbol.GetMembers().OfType<IFieldSymbol>().First(m => m.Name == "Value3");
+
+        diagnostics.ShouldNotBeSuccessful(
+            DiagnosticsFactory.StringEnumMappingSourceOnlyError(missingMember, targetEnumSymbol),
+            ignoreDiagnosticsIds: new[] { "MT3002" });
     }
 }

--- a/test/MapTo.Tests/ScenarioBuilder.cs
+++ b/test/MapTo.Tests/ScenarioBuilder.cs
@@ -287,6 +287,47 @@ internal static class ScenarioBuilder
         return builder;
     }
 
+    public static ITestSourceBuilder SimpleClassWithTwoEnumProperties(
+        TestSourceBuilderOptions? options = null,
+        EnumMappingStrategy? enumMappingStrategy = EnumMappingStrategy.ByValue,
+        bool lowercaseTargetEnum = false)
+    {
+        var builder = new TestSourceBuilder(options);
+        var sourceFile = builder.AddFile();
+        var mapFrom = "[MapFrom(typeof(SourceClass))]";
+        var mapFromWithEnumStrategy = $"[MapFrom(typeof(SourceClass), EnumMappingStrategy = EnumMappingStrategy.{enumMappingStrategy})]";
+
+        sourceFile.WithBody(
+            $$"""
+              public enum SourceEnum
+              {
+                  Value1,
+                  Value2
+              }
+
+              public class SourceClass
+              {
+                  public SourceEnum Prop1 { get; set; }
+                  public SourceEnum Prop2 { get; set; }
+              }
+
+              public enum TargetEnum
+              {
+                  Value1,
+                  {{(lowercaseTargetEnum ? "value2" : "Value2")}}
+              }
+
+              {{(enumMappingStrategy is null or EnumMappingStrategy.ByValue ? mapFrom : mapFromWithEnumStrategy)}}
+              public class TargetClass
+              {
+                  public TargetEnum Prop1 { get; set; }
+                  public TargetEnum Prop2 { get; set; }
+              }
+              """);
+
+        return builder;
+    }
+
     private static string SimpleExpectedExtensionClassThatMapsIdAndNameProperties(ITestSourceBuilder builder) => builder.Options.SupportNullReferenceTypes
         ? $$"""
             {{GeneratedCodeAttribute}}

--- a/test/MapTo.Tests/ScenarioBuilder.cs
+++ b/test/MapTo.Tests/ScenarioBuilder.cs
@@ -328,6 +328,43 @@ internal static class ScenarioBuilder
         return builder;
     }
 
+    public static ITestSourceBuilder EnumWithMapFromAttribute(EnumMappingStrategy enumMappingStrategy, TestSourceBuilderOptions? options = null)
+    {
+        var builder = new TestSourceBuilder(options);
+        var sourceFile = builder.AddFile();
+
+        sourceFile.WithBody(
+            $$"""
+              public enum SourceEnum
+              {
+                  Value1,
+                  Value2
+              }
+
+              public class SourceClass
+              {
+                  public SourceEnum Prop1 { get; set; }
+                  public SourceEnum Prop2 { get; set; }
+              }
+
+              [MapFrom(typeof(SourceEnum), EnumMappingStrategy = EnumMappingStrategy.{{enumMappingStrategy}})]
+              public enum TargetEnum
+              {
+                  Value1,
+                  Value2
+              }
+
+              [MapFrom(typeof(SourceClass))]
+              public class TargetClass
+              {
+                  public TargetEnum Prop1 { get; set; }
+                  public TargetEnum Prop2 { get; set; }
+              }
+              """);
+
+        return builder;
+    }
+
     private static string SimpleExpectedExtensionClassThatMapsIdAndNameProperties(ITestSourceBuilder builder) => builder.Options.SupportNullReferenceTypes
         ? $$"""
             {{GeneratedCodeAttribute}}


### PR DESCRIPTION
Add support to map enums. Mapping can be configured via `MapFromAttribute`, which provides the following new options.

* EnumMappingStrategy: `ByValue`, `ByName` or `ByNameCaseInsensitive`
* EnumMappingFallbackValue: A fallback value to use when the enum value is not found in the target enum. If not provided, it will throw an exception.
* StrictEnumMapping: Indicates how strict the enum mapping should be. The options are `Off`, `SourceOnly`, `TargetOnly` and `SourceAndTarget`.

When using the `StrictEnumMapping` configuration, it is possible to exclude a member using the `IgnoreEnumMemberAttribute`. This attribute can be applied to an enum member directly, on the enum, or the mapping class. Using this attribute, you can ignore a member on a source enum you may not have access to. Applying this attribute to the enum or mapping class is particularly useful in such cases.