### PR TITLE
Initial support for IQueryable projection.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,6 +33,6 @@
     <PackageVersion Include="Mapster" Version="7.4.0-pre06" />
     <PackageVersion Include="TinyMapper" Version="3.0.3" />
     <PackageVersion Include="Riok.Mapperly" Version="3.2.0" />
-    <PackageVersion Include="MapTo" Version="0.9.14" />
+    <PackageVersion Include="MapTo" Version="0.9.22" />
   </ItemGroup>
 </Project>

--- a/src/MapTo.Abstractions/ProjectionType.cs
+++ b/src/MapTo.Abstractions/ProjectionType.cs
@@ -60,6 +60,11 @@ public enum ProjectionType
     ReadOnlyMemory = 1 << 8,
 
     /// <summary>
+    /// Specifies that projection mappings should be generated for <see cref="IQueryable{T}" />.
+    /// </summary>
+    Queryable = 1 << 9,
+
+    /// <summary>
     /// Specifies that projection mappings should be generated for all supported types.
     /// </summary>
     All = ~None

--- a/src/MapTo.Abstractions/PublicAPI.Shipped.txt
+++ b/src/MapTo.Abstractions/PublicAPI.Shipped.txt
@@ -68,4 +68,5 @@ MapTo.ProjectionType.IReadOnlyList = 32 -> MapTo.ProjectionType
 MapTo.ProjectionType.List = 64 -> MapTo.ProjectionType
 MapTo.ProjectionType.Memory = 128 -> MapTo.ProjectionType
 MapTo.ProjectionType.ReadOnlyMemory = 256 -> MapTo.ProjectionType
+MapTo.ProjectionType.Queryable = 512 -> MapTo.ProjectionType
 MapTo.ProjectionType.All = -1 -> MapTo.ProjectionType

--- a/src/MapTo/CodeAnalysis/CompilationExtensions.cs
+++ b/src/MapTo/CodeAnalysis/CompilationExtensions.cs
@@ -42,6 +42,7 @@ internal static class CompilationExtensions
         var memorySymbol = compilation.GetTypeByMetadataName(KnownTypes.SystemMemoryOfT);
         var readOnlyMemorySymbol = compilation.GetTypeByMetadataName(KnownTypes.SystemReadOnlyMemoryOfT);
         var immutableArraySymbol = compilation.GetTypeByMetadataName(KnownTypes.SystemCollectionImmutableArrayOfT);
+        var queryableSymbol = compilation.GetTypeByMetadataName(KnownTypes.SystemLinqIQueryableOfT);
 
         var originalDefinition = namedTypeSymbol.OriginalDefinition;
         typeArguments = namedTypeSymbol.TypeArguments;
@@ -51,7 +52,8 @@ internal static class CompilationExtensions
                 || SymbolEqualityComparer.Default.Equals(originalDefinition, readOnlySpanSymbol)
                 || SymbolEqualityComparer.Default.Equals(originalDefinition, memorySymbol)
                 || SymbolEqualityComparer.Default.Equals(originalDefinition, readOnlyMemorySymbol)
-                || SymbolEqualityComparer.Default.Equals(originalDefinition, immutableArraySymbol)) &&
+                || SymbolEqualityComparer.Default.Equals(originalDefinition, immutableArraySymbol)
+                || SymbolEqualityComparer.Default.Equals(originalDefinition, queryableSymbol)) &&
                namedTypeSymbol.TypeArguments.Length > 0;
     }
 

--- a/src/MapTo/CodeAnalysis/SymbolExtensions.cs
+++ b/src/MapTo/CodeAnalysis/SymbolExtensions.cs
@@ -154,6 +154,11 @@ internal static class SymbolExtensions
         namedTypeSymbol.ContainingNamespace.ToDisplayString() == "System.Collections.Immutable" &&
         namedTypeSymbol.MetadataName == "ImmutableArray`1";
 
+    public static bool IsQueryableOfT(this ITypeSymbol typeSymbol) =>
+        typeSymbol is INamedTypeSymbol { IsGenericType: true } namedTypeSymbol &&
+        namedTypeSymbol.ContainingNamespace.ToDisplayString() == "System.Linq" &&
+        namedTypeSymbol.MetadataName == "IQueryable`1";
+
     public static string ToFullyQualifiedDisplayString(this ITypeSymbol typeSymbol) =>
         $"{typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}{(typeSymbol.NullableAnnotation is NullableAnnotation.Annotated ? "?" : string.Empty)}";
 

--- a/src/MapTo/Configuration/CodeGeneratorOptions.cs
+++ b/src/MapTo/Configuration/CodeGeneratorOptions.cs
@@ -13,6 +13,7 @@ namespace MapTo.Configuration;
 /// <param name="EnumMappingStrategy">Indicates the strategy to use when mapping enum values.</param>
 /// <param name="StrictEnumMapping">Indicates how strict the enum mapping should be.</param>
 /// <param name="ProjectionType">Indicates the type of projection mappings to generate.</param>
+/// <param name="QueryProjectionMethodPrefix">The prefix of the IQueryable projection method.</param>
 internal readonly record struct CodeGeneratorOptions(
     string MapMethodPrefix = "MapTo",
     string MapExtensionClassSuffix = "MapToExtensions",
@@ -21,7 +22,8 @@ internal readonly record struct CodeGeneratorOptions(
     NullHandling NullHandling = NullHandling.Auto,
     EnumMappingStrategy EnumMappingStrategy = EnumMappingStrategy.ByValue,
     StrictEnumMapping StrictEnumMapping = StrictEnumMapping.Off,
-    ProjectionType ProjectionType = ProjectionType.Array | ProjectionType.IEnumerable | ProjectionType.List)
+    ProjectionType ProjectionType = ProjectionType.Array | ProjectionType.IEnumerable | ProjectionType.List,
+    string QueryProjectionMethodPrefix = "Select")
 {
     /// <summary>
     /// The prefix of the property name in the .editorconfig file.
@@ -45,6 +47,7 @@ internal readonly record struct CodeGeneratorOptions(
             NullHandling: provider.GlobalOptions.GetOption<NullHandling>(nameof(NullHandling)),
             EnumMappingStrategy: provider.GlobalOptions.GetOption(nameof(EnumMappingStrategy), EnumMappingStrategy.ByValue),
             StrictEnumMapping: provider.GlobalOptions.GetOption(nameof(StrictEnumMapping), StrictEnumMapping.Off),
-            ProjectionType: provider.GlobalOptions.GetOption(nameof(ProjectionType),  ProjectionType.Array | ProjectionType.IEnumerable | ProjectionType.List));
+            ProjectionType: provider.GlobalOptions.GetOption(nameof(ProjectionType),  ProjectionType.Array | ProjectionType.IEnumerable | ProjectionType.List),
+            QueryProjectionMethodPrefix: provider.GlobalOptions.GetOption(nameof(QueryProjectionMethodPrefix), "Select"));
     }
 }

--- a/src/MapTo/Generators/ExtensionClassGenerator.cs
+++ b/src/MapTo/Generators/ExtensionClassGenerator.cs
@@ -316,61 +316,6 @@ static file class ExtensionClassGeneratorExtensions
         };
     }
 
-    private static CodeWriter WriteConstructorInitializer(this CodeWriter writer, TargetMapping mapping)
-    {
-        var sourceType = mapping.Source.Name;
-        var parameterName = sourceType.ToParameterNameCasing();
-        var hasObjectInitializer = mapping.Properties.Any(p => p.InitializationMode == PropertyInitializationMode.ObjectInitializer);
-
-        if (!mapping.Constructor.HasParameters)
-        {
-            writer.Write($"new {mapping.Name}");
-            return hasObjectInitializer ? writer.WriteNewLine() : writer.WriteLine("();");
-        }
-
-        writer.Write($"new {mapping.Name}(");
-
-        for (var i = 0; i < mapping.Constructor.Parameters.Length; i++)
-        {
-            var parameter = mapping.Constructor.Parameters[i];
-
-            if (mapping.Constructor.HasParameterWithDefaultValue)
-            {
-                writer.Write(parameter.Name).Write(": ");
-            }
-
-            PropertyGenerator.Instance.Generate(new(writer, parameter.Property, parameterName, null, mapping.Options.CopyPrimitiveArrays, null));
-            writer.WriteIf(i < mapping.Constructor.Parameters.Length - 1, ", ");
-        }
-
-        return hasObjectInitializer ? writer.WriteLine(")") : writer.WriteLine(");");
-    }
-
-    private static CodeWriter WriteObjectInitializer(this CodeWriter writer, TargetMapping mapping)
-    {
-        var properties = mapping.Properties.Where(p => p.InitializationMode == PropertyInitializationMode.ObjectInitializer).ToArray();
-        if (properties.Length == 0)
-        {
-            return writer;
-        }
-
-        var sourceType = mapping.Source.Name;
-        var parameterName = sourceType.ToParameterNameCasing();
-
-        writer.WriteOpeningBracket();
-
-        for (var i = 0; i < properties.Length; i++)
-        {
-            var property = properties[i];
-
-            writer.Write($"{property.Name} = ");
-            PropertyGenerator.Instance.Generate(new(writer, property, parameterName, null, mapping.Options.CopyPrimitiveArrays, null));
-            writer.WriteIf(i < properties.Length - 1, ",").WriteLineIndented();
-        }
-
-        return writer.WriteClosingBracket(false).WriteLine(";");
-    }
-
     private static CodeWriter WriteParameterNullCheck(this CodeWriter writer, string parameterName) => writer
         .Write("if (").WriteIsNullCheck(parameterName).WriteLine(")")
         .WriteOpeningBracket()

--- a/src/MapTo/Generators/TypeInitializerGenerator.cs
+++ b/src/MapTo/Generators/TypeInitializerGenerator.cs
@@ -1,0 +1,75 @@
+﻿using MapTo.Extensions;
+using MapTo.Mappings;
+
+namespace MapTo.Generators;
+
+internal static class TypeInitializerGenerator
+{
+    internal static CodeWriter WriteConstructorInitializer(this CodeWriter writer, TargetMapping mapping) =>
+        WriteConstructorInitializer(writer, mapping.ToTypeInitializerMapping());
+
+    internal static CodeWriter WriteConstructorInitializer(this CodeWriter writer, TypeInitializerMapping mapping, bool inline = false)
+    {
+        var (sourceName, targetName, targetConstructor, targetProperties, options) = mapping;
+        var sourceType = sourceName;
+        var parameterName = sourceType.ToParameterNameCasing();
+        var hasObjectInitializer = targetProperties.Any(p => p.InitializationMode == PropertyInitializationMode.ObjectInitializer);
+
+        if (!targetConstructor.HasParameters)
+        {
+            writer.Write($"new {targetName}");
+            return hasObjectInitializer ? writer.WriteNewLine() : writer.WriteLine("();");
+        }
+
+        writer.Write($"new {targetName}(");
+
+        for (var i = 0; i < targetConstructor.Parameters.Length; i++)
+        {
+            var parameter = targetConstructor.Parameters[i];
+
+            if (targetConstructor.HasParameterWithDefaultValue)
+            {
+                writer.Write(parameter.Name).Write(": ");
+            }
+
+            PropertyGenerator.Instance.Generate(new(writer, parameter.Property, parameterName, null, options.CopyPrimitiveArrays, null));
+            writer.WriteIf(i < targetConstructor.Parameters.Length - 1, ", ");
+        }
+
+        return (inline, hasObjectInitializer) switch
+        {
+            (_, true) => writer.WriteLine(")"),
+            (true, false) => writer.Write(")"),
+            (false, false) => writer.WriteLine(");")
+        };
+    }
+
+    internal static CodeWriter WriteObjectInitializer(this CodeWriter writer, TargetMapping mapping) =>
+        WriteObjectInitializer(writer, mapping.ToTypeInitializerMapping());
+
+    internal static CodeWriter WriteObjectInitializer(this CodeWriter writer, TypeInitializerMapping mapping, bool inline = false)
+    {
+        var (sourceName, _, _, targetProperties, options) = mapping;
+        var properties = targetProperties.Where(p => p.InitializationMode == PropertyInitializationMode.ObjectInitializer).ToArray();
+        if (properties.Length == 0)
+        {
+            return writer;
+        }
+
+        var sourceType = sourceName;
+        var parameterName = sourceType.ToParameterNameCasing();
+
+        writer.WriteOpeningBracket();
+
+        for (var i = 0; i < properties.Length; i++)
+        {
+            var property = properties[i];
+
+            writer.Write($"{property.Name} = ");
+            PropertyGenerator.Instance.Generate(new(writer, property, parameterName, null, options.CopyPrimitiveArrays, null));
+            writer.WriteIf(i < properties.Length - 1, ",").WriteLineIndented();
+        }
+
+        return writer.WriteClosingBracket(false).WriteLineIf(!inline, ";");
+    }
+}

--- a/src/MapTo/KnownTypes.cs
+++ b/src/MapTo/KnownTypes.cs
@@ -20,6 +20,7 @@ internal record KnownTypes(
     internal const string LinqEnumerable = "System.Linq.Enumerable";
     internal const string LinqToArray = "System.Linq.Enumerable.ToArray";
     internal const string LinqToList = "System.Linq.Enumerable.ToList";
+    internal const string LinqQueryable = "System.Linq.Queryable";
     internal const string SystemSpanOfT = "System.Span`1";
     internal const string SystemReadOnlySpanOfT = "System.ReadOnlySpan`1";
     internal const string SystemMemoryOfT = "System.Memory`1";

--- a/src/MapTo/Mappings/EnumerableType.cs
+++ b/src/MapTo/Mappings/EnumerableType.cs
@@ -9,17 +9,18 @@ internal enum EnumerableType
     ReadOnlyList,
     Collection,
     ReadOnlyCollection,
+    Queryable,
     Span,
     ReadOnlySpan,
     Memory,
     ReadOnlyMemory,
-    ImmutableArray
+    ImmutableArray,
 }
 
 internal static class EnumerableTypeExtensions
 {
     internal static bool IsCountable(this EnumerableType enumerableType) =>
-        enumerableType is not EnumerableType.None and not EnumerableType.Enumerable;
+        enumerableType is not EnumerableType.None and not EnumerableType.Enumerable and not EnumerableType.Queryable;
 
     internal static bool IsFixedSize(this EnumerableType enumerableType) => enumerableType is
         EnumerableType.Array or EnumerableType.Span or EnumerableType.Memory or EnumerableType.ImmutableArray or
@@ -30,6 +31,8 @@ internal static class EnumerableTypeExtensions
     internal static bool HasIndexer(this EnumerableType enumerableType) => enumerableType is
         EnumerableType.Array or EnumerableType.Span or EnumerableType.List or EnumerableType.ReadOnlyList or
         EnumerableType.ImmutableArray or EnumerableType.Memory or EnumerableType.ReadOnlyMemory or EnumerableType.ReadOnlySpan;
+
+    internal static bool IsQueryable(this EnumerableType enumerableType) => enumerableType is EnumerableType.Queryable;
 
     internal static string ToLinqSourceCodeString(this EnumerableType enumerableType) => enumerableType switch
     {
@@ -42,6 +45,7 @@ internal static class EnumerableTypeExtensions
         EnumerableType.Memory => "AsMemory()",
         EnumerableType.ReadOnlyMemory => "AsMemory()",
         EnumerableType.ImmutableArray => "ToImmutableArray()",
+        EnumerableType.Queryable => "AsQueryable()",
         _ => "ToList()"
     };
 }

--- a/src/MapTo/Mappings/ProjectionMapping.cs
+++ b/src/MapTo/Mappings/ProjectionMapping.cs
@@ -56,7 +56,9 @@ internal readonly record struct ProjectionMapping(
             return Enumerable.Empty<ProjectionMapping>();
         }
 
-        var methodName = $"{context.CodeGeneratorOptions.MapMethodPrefix}{context.TargetTypeSyntax.Identifier.Text}".Pluralize();
+        static string GetMethodName(CodeGeneratorOptions o, string name, ProjectionType type) =>
+            type is ProjectionType.Queryable ? $"{o.QueryProjectionMethodPrefix}{name}".Pluralize() : $"{o.MapMethodPrefix}{name}".Pluralize();
+
         var accessibility = context.TargetTypeSyntax.GetAccessibility();
         var projectionType = context.CodeGeneratorOptions.ProjectionType;
 
@@ -66,7 +68,7 @@ internal readonly record struct ProjectionMapping(
             .Select(p => new ProjectionMapping(
                 Accessibility: accessibility,
                 OriginalAccessibility: accessibility,
-                MethodName: methodName,
+                MethodName: GetMethodName(context.CodeGeneratorOptions, context.TargetTypeSyntax.Identifier.Text, p),
                 ReturnType: CreateTypeMapping(context.TargetTypeSymbol, p, context.Compilation),
                 ParameterType: CreateTypeMapping(context.SourceTypeSymbol, p, context.Compilation),
                 ParameterName: "source",
@@ -86,6 +88,7 @@ internal readonly record struct ProjectionMapping(
             ProjectionType.List => compilation.CreateGenericTypeSymbol(KnownTypes.SystemCollectionsGenericListOfT, typeSymbol),
             ProjectionType.Memory => compilation.CreateGenericTypeSymbol(KnownTypes.SystemMemoryOfT, typeSymbol),
             ProjectionType.ReadOnlyMemory => compilation.CreateGenericTypeSymbol(KnownTypes.SystemReadOnlyMemoryOfT, typeSymbol),
+            ProjectionType.Queryable => compilation.CreateGenericTypeSymbol(KnownTypes.SystemLinqIQueryableOfT, typeSymbol),
             _ => throw new ArgumentOutOfRangeException(nameof(projectionType), projectionType, $"Invalid projection type '{projectionType}'.")
         };
 

--- a/src/MapTo/Mappings/TypeInitializerMapping.cs
+++ b/src/MapTo/Mappings/TypeInitializerMapping.cs
@@ -1,0 +1,18 @@
+﻿namespace MapTo.Mappings;
+
+internal readonly record struct TypeInitializerMapping(
+    string SourceName,
+    string TargetName,
+    ConstructorMapping TargetConstructor,
+    ImmutableArray<PropertyMapping> TargetProperties,
+    CodeGeneratorOptions Options);
+
+internal static class TypeInitializerMappingExtensions
+{
+    internal static TypeInitializerMapping ToTypeInitializerMapping(this TargetMapping mapping, string? sourceName = null) => new(
+        SourceName: sourceName ?? mapping.Source.Name,
+        TargetName: mapping.Name,
+        TargetConstructor: mapping.Constructor,
+        TargetProperties: mapping.Properties,
+        Options: mapping.Options);
+}

--- a/src/MapTo/Mappings/TypeMapping.cs
+++ b/src/MapTo/Mappings/TypeMapping.cs
@@ -16,7 +16,6 @@ internal readonly record struct TypeMapping(
     NullableAnnotation ElementTypeNullableAnnotation,
     bool IsCountable,
     bool IsFixedSize,
-    bool IsImmutable,
     bool IsReferenceType,
     SpecialType SpecialType)
 {
@@ -65,7 +64,6 @@ internal static class TypeMappingExtensions
             SpecialType: typeSymbol.SpecialType,
             IsCountable: enumerableType.IsCountable(),
             IsFixedSize: enumerableType.IsFixedSize(),
-            IsImmutable: enumerableType.IsImmutable(),
             IsReferenceType: typeSymbol.IsReferenceType);
 
 #if DEBUG
@@ -92,6 +90,7 @@ internal static class TypeMappingExtensions
         _ when typeSymbol.IsReadOnlyMemoryOfT() => EnumerableType.ReadOnlyMemory,
         _ when typeSymbol.IsMemoryOfT() => EnumerableType.Memory,
         _ when typeSymbol.IsImmutableArrayOfT() => EnumerableType.ImmutableArray,
+        _ when typeSymbol.IsQueryableOfT() => EnumerableType.Queryable,
         _ when typeSymbol.IsGenericCollectionOf(SpecialType.System_Collections_Generic_IList_T) => EnumerableType.List,
         _ when typeSymbol.IsGenericCollectionOf(SpecialType.System_Collections_Generic_ICollection_T) => EnumerableType.Collection,
         _ when typeSymbol.IsGenericCollectionOf(SpecialType.System_Collections_Generic_IReadOnlyList_T) => EnumerableType.ReadOnlyList,

--- a/stylecop.ruleset
+++ b/stylecop.ruleset
@@ -15,7 +15,7 @@
         <Rule Id="SA1007"  Action="Warning" />          <!-- Operator keyword should be followed by space -->
         <Rule Id="SA1008"  Action="Warning" />          <!-- Opening parenthesis should be spaced correctly -->
         <Rule Id="SA1009"  Action="Warning" />          <!-- Closing parenthesis should be spaced correctly -->
-        <Rule Id="SA1010"  Action="Warning" />          <!-- Opening square brackets should be spaced correctly -->
+        <Rule Id="SA1010"  Action="None" />             <!-- Opening square brackets should be spaced correctly -->
         <Rule Id="SA1011"  Action="Warning" />          <!-- Closing square brackets should be spaced correctly -->
         <Rule Id="SA1012"  Action="Warning" />          <!-- Opening braces should be spaced correctly -->
         <Rule Id="SA1013"  Action="Warning" />          <!-- Closing braces should be spaced correctly -->

--- a/test/MapTo.Tests/CodeGeneratorOptionsTests.cs
+++ b/test/MapTo.Tests/CodeGeneratorOptionsTests.cs
@@ -13,6 +13,7 @@ public class CodeGeneratorOptionsTests
     [InlineData(nameof(CodeGeneratorOptions.ProjectionType), "IEnumerable", ProjectionType.IEnumerable)]
     [InlineData(nameof(CodeGeneratorOptions.ProjectionType), "Array | IEnumerable", ProjectionType.Array | ProjectionType.IEnumerable)]
     [InlineData(nameof(CodeGeneratorOptions.ProjectionType), "3", ProjectionType.Array | ProjectionType.IEnumerable)]
+    [InlineData(nameof(CodeGeneratorOptions.QueryProjectionMethodPrefix), "Select", "Select")]
     public void Verify_AnalyzerConfigOption(string configName, string value, object expectedValue)
     {
         // Arrange

--- a/test/MapTo.Tests/Infrastructure/CSharpGenerator.cs
+++ b/test/MapTo.Tests/Infrastructure/CSharpGenerator.cs
@@ -1,18 +1,70 @@
-﻿namespace MapTo.Tests.Infrastructure;
+﻿using System.Reflection;
+
+namespace MapTo.Tests.Infrastructure;
 
 internal static class CSharpGenerator
 {
-    private static readonly string[] IgnoredDiagnosticIds = { "MT" };
-    private static readonly string[] AssertionSuppressedDiagnosticIds = { "CS0436" };
-    private static readonly IIncrementalGenerator[] SourceGenerators = { new MapToGenerator() };
+    private static readonly string[] IgnoredDiagnosticIds = ["MT"];
+    private static readonly IIncrementalGenerator[] SourceGenerators = [new MapToGenerator()];
+
+    private static readonly string[] SdkAssemblies =
+    [
+        "Microsoft.CSharp",
+        "netstandard",
+        "System.Collections",
+        "System.Collections.Concurrent",
+        "System.Collections.Immutable",
+        "System.Collections.NonGeneric",
+        "System.ComponentModel",
+        "System.ComponentModel.Primitives",
+        "System.ComponentModel.TypeConverter",
+        "System.Console",
+        "System.Diagnostics.Debug",
+        "System.Diagnostics.Process",
+        "System.Diagnostics.TraceSource",
+        "System.Diagnostics.Tracing",
+        "System.Globalization",
+        "System.IO",
+        "System.IO.FileSystem",
+        "System.Linq",
+        "System.Linq.Expressions",
+        "System.Linq.Queryable",
+        "System.Memory",
+        "System.Net.Primitives",
+        "System.Net.Sockets",
+        "System.ObjectModel",
+        "System.Private.CoreLib",
+        "System.Private.Uri",
+        "System.Reflection",
+        "System.Reflection.Emit",
+        "System.Reflection.Emit.ILGeneration",
+        "System.Reflection.Emit.Lightweight",
+        "System.Reflection.Extensions",
+        "System.Reflection.Metadata",
+        "System.Reflection.Primitives",
+        "System.Runtime",
+        "System.Runtime.Extensions",
+        "System.Runtime.InteropServices",
+        "System.Runtime.Intrinsics",
+        "System.Runtime.Loader",
+        "System.Runtime.Numerics",
+        "System.Runtime.Serialization.Formatters",
+        "System.Text.Encoding.Extensions",
+        "System.Text.RegularExpressions",
+        "System.Threading",
+        "System.Threading.Tasks",
+        "System.Threading.Thread",
+        "System.Threading.ThreadPool"
+    ];
+
+    private static readonly string[] MapToAssemblies = ["MapTo", "MapTo.Abstractions"];
 
     internal static CompilationResult GetOutputCompilation(
         string source,
         bool assertCompilation = false,
         IDictionary<string, string>? analyzerConfigOptions = null,
         NullableContextOptions nullableContextOptions = NullableContextOptions.Disable,
-        LanguageVersion languageVersion = LanguageVersion.CSharp8,
-        bool assertOutputCompilation = true) =>
+        LanguageVersion languageVersion = LanguageVersion.CSharp8) =>
         GetOutputCompilation(
             new[] { new TestSource(string.Empty, source, languageVersion, true) },
             assertCompilation,
@@ -29,10 +81,11 @@ internal static class CSharpGenerator
         LanguageVersion languageVersion = LanguageVersion.CSharp8,
         bool assertOutputCompilation = true)
     {
-        var references = AppDomain.CurrentDomain.GetAssemblies()
-            .Where(a => !a.IsDynamic && !string.IsNullOrWhiteSpace(a.Location))
-            .Select(a => MetadataReference.CreateFromFile(a.Location))
-            .ToList();
+        var sdkDir = Path.GetDirectoryName(typeof(object).Assembly.Location) ?? throw new InvalidOperationException("Could not find SDK directory");
+        var workingDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? throw new InvalidOperationException("Could not find working directory");
+        var references = SdkAssemblies.Select(s => Path.Combine(sdkDir, $"{s}.dll"))
+            .Union(MapToAssemblies.Select(s => Path.Combine(workingDir, $"{s}.dll")))
+            .Select(s => MetadataReference.CreateFromFile(s));
 
         var compilation = CSharpCompilation.Create(
             $"{typeof(CSharpGenerator).Assembly.GetName().Name}.Dynamic",
@@ -55,8 +108,12 @@ internal static class CSharpGenerator
 
         if (assertOutputCompilation)
         {
-            generateDiagnostics.ShouldBeSuccessful(ignoreDiagnosticsIds: IgnoredDiagnosticIds);
-            outputCompilation.GetDiagnostics().ShouldBeSuccessful(outputCompilation, ignoreDiagnosticsIds: AssertionSuppressedDiagnosticIds);
+            var compilationDiagnostics = outputCompilation.GetDiagnostics();
+            var suppressedErrors = compilationDiagnostics.All(c => c.Severity is not DiagnosticSeverity.Error) ? IgnoredDiagnosticIds : [];
+
+            generateDiagnostics.Union(compilationDiagnostics)
+                .Where(d => suppressedErrors.All(i => !d.Id.StartsWith(i)))
+                .ShouldBeSuccessful();
         }
 
         return new(outputCompilation, generateDiagnostics);

--- a/test/MapTo.Tests/MapProjectionTests.cs
+++ b/test/MapTo.Tests/MapProjectionTests.cs
@@ -359,6 +359,71 @@ public class MapProjectionTests
     }
 
     [Fact]
+    public void When_ProjectionIsQueryable_Should_GenerateProjectionExtensionMethods()
+    {
+        // Arrange
+        var builder = ScenarioBuilder.SimpleMappedRecordInSameNamespace(mapFromProjectionType: ProjectionType.Queryable);
+
+        // Act
+        var (compilation, diagnostics) = builder.Compile();
+
+        // Assert
+        diagnostics.ShouldBeSuccessful();
+        var extensionClass = compilation.GetClassDeclaration("SourceRecordMapToExtensions").ShouldNotBeNull();
+        var methods = extensionClass.Members.OfType<MethodDeclarationSyntax>().ToArray();
+        methods.Length.ShouldBe(2);
+        methods[1].ShouldBe(
+            """
+            [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("source")]
+            public static global::System.Linq.IQueryable<global::MapTo.Tests.DestinationRecord>? SelectDestinationRecords(this global::System.Linq.IQueryable<global::MapTo.Tests.SourceRecord>? source)
+            {
+                if (source is null)
+                {
+                    return null;
+                }
+
+            #nullable disable
+                return global::System.Linq.Queryable.Select(source, x => new DestinationRecord(x.Value));
+            #nullable enable
+            }
+            """);
+    }
+
+    [Fact]
+    public void When_ProjectionIsQueryable_Should_GenerateProjectionExtensionMethodWithCorrectPrefix()
+    {
+        // Arrange
+        const string ExpectedQueryProjectionMethodPrefix = "SelectTo";
+        var options = TestSourceBuilderOptions.Create(supportNullReferenceTypes: true);
+        options.AddAnalyzerConfigOption(nameof(CodeGeneratorOptions.QueryProjectionMethodPrefix), ExpectedQueryProjectionMethodPrefix);
+        var builder = ScenarioBuilder.SimpleMappedRecordInSameNamespace(options, ProjectionType.Queryable);
+
+        // Act
+        var (compilation, diagnostics) = builder.Compile();
+
+        // Assert
+        diagnostics.ShouldBeSuccessful();
+        var extensionClass = compilation.GetClassDeclaration("SourceRecordMapToExtensions").ShouldNotBeNull();
+        var methods = extensionClass.Members.OfType<MethodDeclarationSyntax>().ToArray();
+        methods.Length.ShouldBe(2);
+        methods[1].ShouldBe(
+            $$"""
+            [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("source")]
+            public static global::System.Linq.IQueryable<global::MapTo.Tests.DestinationRecord>? {{ExpectedQueryProjectionMethodPrefix}}DestinationRecords(this global::System.Linq.IQueryable<global::MapTo.Tests.SourceRecord>? source)
+            {
+                if (source is null)
+                {
+                    return null;
+                }
+
+            #nullable disable
+                return global::System.Linq.Queryable.Select(source, x => new DestinationRecord(x.Value));
+            #nullable enable
+            }
+            """);
+    }
+
+    [Fact]
     public void When_MultipleProjectionsExist_Should_GenerateProjectionExtensionMethodsForEach()
     {
         // Arrange

--- a/test/MapTo.Tests/ScenarioBuilder.cs
+++ b/test/MapTo.Tests/ScenarioBuilder.cs
@@ -58,7 +58,7 @@ internal static class ScenarioBuilder
         var builder = new TestSourceBuilder(TestSourceBuilderOptions.Create(supportNullReferenceTypes: supportNullReferenceTypes));
         builder.AddFile(
                 supportNullableReferenceTypes: supportNullReferenceTypes,
-                usings: new[] { "System", "System.Collections.Generic", "System.Collections.Immutable", "System.Collections.ObjectModel" })
+                usings: new[] { "System", "System.Collections.Generic", "System.Collections.Immutable", "System.Collections.ObjectModel", "System.Linq" })
             .WithBody(
                 $$"""
                   public record SourceRecord(int Value);


### PR DESCRIPTION
Add initial support for IQueryable projection. This allows us to automatically generate the projection method using the `ProjectTo` property of the `MapFrom` attribute or create a `static partial` class.

Closes #13 