### PR TITLE
Fix not reporting correct error when property type is enumerable with a type converter

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ root = true
 # Indentation, spacing and new line
 [*]
 charset = utf-8
-trim_trailing_whitespace = false
+trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
 tab_width = 4
@@ -74,6 +74,8 @@ ij_formatter_tags_enabled = false
 ij_smart_tabs = false
 ij_visual_guides = none
 ij_wrap_on_typing = false
+ij_xml_space_inside_empty_tag = true
+ij_html_space_inside_empty_tag = true
 
 [*.css]
 ij_css_align_closing_brace_with_properties = false

--- a/src/MapTo/Mappings/Handlers/ArrayTypeConverterResolver.cs
+++ b/src/MapTo/Mappings/Handlers/ArrayTypeConverterResolver.cs
@@ -10,6 +10,12 @@ internal class ArrayTypeConverterResolver : ITypeConverterResolver
             return ResolverResult.Undetermined<TypeConverterMapping>();
         }
 
+        var typeConverterAttribute = property.GetAttribute(context.KnownTypes.PropertyTypeConverterAttributeTypeSymbol);
+        if (typeConverterAttribute is not null)
+        {
+            return ResolverResult.Undetermined<TypeConverterMapping>();
+        }
+
         var mapFromAttribute = arrayNamedTypeSymbol.GetAttribute(context.KnownTypes.MapFromAttributeTypeSymbol);
         var propertyTypeName = arrayNamedTypeSymbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
         var mappedSourcePropertyType = mapFromAttribute?.ConstructorArguments.First().Value as INamedTypeSymbol ?? arrayNamedTypeSymbol;

--- a/src/MapTo/Mappings/Handlers/EnumerableTypeConverterResolver.cs
+++ b/src/MapTo/Mappings/Handlers/EnumerableTypeConverterResolver.cs
@@ -10,6 +10,12 @@ internal class EnumerableTypeConverterResolver : ITypeConverterResolver
             return ResolverResult.Undetermined<TypeConverterMapping>();
         }
 
+        var typeConverterAttribute = property.GetAttribute(context.KnownTypes.PropertyTypeConverterAttributeTypeSymbol);
+        if (typeConverterAttribute is not null)
+        {
+            return ResolverResult.Undetermined<TypeConverterMapping>();
+        }
+
         if (property.Type is not INamedTypeSymbol enumerableTypeSymbol || enumerableTypeSymbol.TypeArguments.IsEmpty)
         {
             return DiagnosticsFactory.SuitableMappingTypeInNestedPropertyNotFoundError(property, property.Type);

--- a/test/MapTo.Tests/Infrastructure/CSharpGenerator.cs
+++ b/test/MapTo.Tests/Infrastructure/CSharpGenerator.cs
@@ -96,7 +96,7 @@ internal static class CSharpGenerator
         if (assertCompilation)
         {
             // NB: fail tests when the injected program isn't valid _before_ running generators
-            compilation.GetDiagnostics().ShouldBeSuccessful();
+            compilation.ShouldBeSuccessful();
         }
 
         var driver = CSharpGeneratorDriver.Create(
@@ -113,7 +113,7 @@ internal static class CSharpGenerator
 
             generateDiagnostics.Union(compilationDiagnostics)
                 .Where(d => suppressedErrors.All(i => !d.Id.StartsWith(i)))
-                .ShouldBeSuccessful();
+                .ShouldBeSuccessful(outputCompilation);
         }
 
         return new(outputCompilation, generateDiagnostics);

--- a/test/MapTo.Tests/MapFromCollectionTests.cs
+++ b/test/MapTo.Tests/MapFromCollectionTests.cs
@@ -177,7 +177,7 @@ public class MapFromCollectionTests
                     {
                         targetArray[i] = global::MapTo.Tests.EmployeeMapToExtensions.MapToEmployeeModel(sourceArray[i]);
                     }
-                
+
                     return targetArray;
                 }
                 """);
@@ -211,7 +211,7 @@ public class MapFromCollectionTests
                 {
                     targetArray[i] = global::MapTo.Tests.ArtistMapToExtensions.MapToArtistViewModel(sourceArray[i], referenceHandler);
                 }
-            
+
                 return targetArray;
             }
             """);
@@ -245,7 +245,7 @@ public class MapFromCollectionTests
                 {
                     targetArray[i] = global::ExternalTestData.Models.ArtistDtoMapToExtensions.MapToArtist(sourceArray[i]);
                 }
-            
+
                 return targetArray;
             }
             """);
@@ -281,7 +281,7 @@ public class MapFromCollectionTests
                 {
                     targetArray[i] = global::ExternalTestData.Models.ArtistDtoMapToExtensions.MapToArtist(sourceArray[i], referenceHandler);
                  }
-            
+
                  return targetArray;
              }
             """);
@@ -297,7 +297,7 @@ public class MapFromCollectionTests
                 {
                     targetArray[i] = global::ExternalTestData.Models.CopyrightDtoMapToExtensions.MapToCopyright(sourceArray[i]);
                 }
-            
+
                 return targetArray;
             }
             """);
@@ -332,7 +332,7 @@ public class MapFromCollectionTests
             {
                 var targetArray = new string[sourceArray.Length];
                 global::System.Array.Copy(sourceArray, targetArray, sourceArray.Length);
-            
+
                 return targetArray;
             }
             """);


### PR DESCRIPTION
Fix not reporting the correct error when the PropertyTypeConverter is for an enumerable type.