### PR TITLE
Requesting for ignored required properties from the map method.

### DIFF
--- a/src/MapTo/Generators/ExtensionClassGenerator.cs
+++ b/src/MapTo/Generators/ExtensionClassGenerator.cs
@@ -158,7 +158,17 @@ static file class ExtensionClassGeneratorExtensions
             .Write(sourceType)
             .Write(compilerOptions.NullableReferenceSyntax)
             .WriteWhitespace()
-            .Write(parameterName)
+            .Write(parameterName);
+
+        // If there are any required properties with ignored attribute, we should add them as parameters
+        foreach (var property in mapping.Properties.Where(p => p is { IsRequired: true, InitializationMode: PropertyInitializationMode.None }))
+        {
+            var parameterType = property.TypeName;
+            var parameter = property.Name.ToParameterNameCasing();
+            writer.Write(", ").Write(parameterType).WriteWhitespace().Write(parameter);
+        }
+
+        writer
             .WriteClosingParenthesis()
             .WriteOpeningBracket(); // Method opening bracket
 

--- a/src/MapTo/Mappings/PropertyInitializationMode.cs
+++ b/src/MapTo/Mappings/PropertyInitializationMode.cs
@@ -2,6 +2,7 @@
 
 internal enum PropertyInitializationMode
 {
+    None,
     Constructor,
     ObjectInitializer,
     Setter


### PR DESCRIPTION
If a type has an ignored required property, the generator will now ask for a value for the property from the mapping extension method.

For instance:
```csharp
public record Source
{
    public int Prop1 { get; init; }
    public double Prop2 { get; init; }
}

[MapFrom(typeof(Source))]
public record Target
{
    public required int Prop1 { get; init; }

    [IgnoreProperty]
    public required double Prop2 { get; init; }
}
```
will generate:
```csharp
public static Target? MapToTarget(this Source? source, double prop2)
{
    if (source is null)
    {
        return null;
    }

    return new Target
    {
        Prop1 = source.Prop1,
        Prop2 = prop2
    };
}
```