### PR TITLE
Fix PropertyTypeConverter error when nameof is used with a type in another file

### DIFF
--- a/src/MapTo/Mappings/Handlers/ExplicitTypeConverterResolver.cs
+++ b/src/MapTo/Mappings/Handlers/ExplicitTypeConverterResolver.cs
@@ -56,8 +56,7 @@ internal class ExplicitTypeConverterResolver : ITypeConverterResolver
 
         converterMethodSymbol = argumentExpressions.FirstOrDefault() switch
         {
-            InvocationExpressionSyntax { Expression: IdentifierNameSyntax { Identifier.ValueText: "nameof" }, ArgumentList.Arguments: { Count: 1 } arguments } =>
-                context.TargetSemanticModel.GetSymbolInfo(arguments[0].Expression).GetSymbolOrBestCandidate<IMethodSymbol>(),
+            InvocationExpressionSyntax { Expression: IdentifierNameSyntax { Identifier.ValueText: "nameof" } } i => context.Compilation.GetMethodSymbol(i),
             LiteralExpressionSyntax { Token.Value: string value } when value.Contains(".") => context.Compilation.GetMethodSymbolByFullyQualifiedName(value.AsSpan()),
             LiteralExpressionSyntax { Token.Value: string value } => context.TargetTypeSymbol.GetMembers(value).OfType<IMethodSymbol>().SingleOrDefault(),
             _ => null

--- a/src/MapTo/Mappings/MethodMapping.cs
+++ b/src/MapTo/Mappings/MethodMapping.cs
@@ -51,8 +51,7 @@ internal readonly record struct MethodMapping(
 
         return argumentExpression switch
         {
-            InvocationExpressionSyntax { Expression: IdentifierNameSyntax { Identifier.ValueText: "nameof" }, ArgumentList.Arguments: { Count: 1 } arguments } =>
-                context.TargetSemanticModel.GetSymbolInfo(arguments[0].Expression).GetSymbolOrBestCandidate<IMethodSymbol>(),
+            InvocationExpressionSyntax { Expression: IdentifierNameSyntax { Identifier.ValueText: "nameof" } } i => context.Compilation.GetMethodSymbol(i),
             LiteralExpressionSyntax { Token.Value: string value } when value.Contains(".") => context.Compilation.GetMethodSymbolByFullyQualifiedName(value.AsSpan()),
             LiteralExpressionSyntax { Token.Value: string value } => context.TargetTypeSymbol.GetMembers(value).OfType<IMethodSymbol>().SingleOrDefault(),
             _ => default


### PR DESCRIPTION
Fix PropertyTypeConverter error when nameof is used with a type in another file