### PR TITLE
Fix incorrect mapping when the source and target class names are the same

### DIFF
--- a/src/MapTo/Generators/ExtensionClassGenerator.cs
+++ b/src/MapTo/Generators/ExtensionClassGenerator.cs
@@ -38,7 +38,8 @@ static file class ExtensionClassGeneratorExtensions
     {
         const string ParameterName = "sourceArray";
         var referenceHandler = mapping.Options.ReferenceHandling == ReferenceHandling.Enabled ? "referenceHandler" : null;
-        var properties = mapping.Properties
+
+        var properties = (!mapping.Properties.IsDefaultOrEmpty ? mapping.Properties : mapping.Constructor.Parameters.Select(p => p.Property))
             .Where(p => p is { SourceType.IsArray: true, TypeConverter: { IsMapToExtensionMethod: true, Type.EnumerableType: EnumerableType.Array } })
             .Select(p => (
                 ReturnType: $"{p.Type.ElementTypeName}[]",
@@ -52,7 +53,7 @@ static file class ExtensionClassGeneratorExtensions
         {
             var propertyMap = typeConverter switch
             {
-                { HasParameter: false, ReferenceHandling: false } => $"{typeConverter.ContainingType}.{typeConverter.MethodName}({ParameterName}[i])",
+                { HasParameter: false, ReferenceHandling: false } => $"{typeConverter.MethodFullName}({ParameterName}[i])",
                 { HasParameter: false, ReferenceHandling: true } => $"{typeConverter.ContainingType}.{typeConverter.MethodName}({ParameterName}[i], {referenceHandler})",
                 _ => $"{ParameterName}[i]"
             };

--- a/src/MapTo/Mappings/Handlers/ArrayTypeConverterResolver.cs
+++ b/src/MapTo/Mappings/Handlers/ArrayTypeConverterResolver.cs
@@ -22,7 +22,7 @@ internal class ArrayTypeConverterResolver : ITypeConverterResolver
         var methodPrefix = context.CodeGeneratorOptions.MapMethodPrefix;
 
         return new TypeConverterMapping(
-            ContainingType: mappedSourcePropertyType.ToExtensionClassName(context.CodeGeneratorOptions),
+            ContainingType: mappedSourcePropertyType.ToExtensionClassName(context),
             MethodName: mappedSourcePropertyType.IsPrimitiveType() ? $"{methodPrefix}{mappedSourcePropertyType.Name}" : $"{methodPrefix}{propertyTypeName}",
             Parameter: null,
             Type: property.Type.ToTypeMapping(),

--- a/src/MapTo/Mappings/Handlers/EnumerableTypeConverterResolver.cs
+++ b/src/MapTo/Mappings/Handlers/EnumerableTypeConverterResolver.cs
@@ -32,7 +32,7 @@ internal class EnumerableTypeConverterResolver : ITypeConverterResolver
         var methodPrefix = context.CodeGeneratorOptions.MapMethodPrefix;
 
         return new TypeConverterMapping(
-            ContainingType: mappedSourcePropertyType.ToExtensionClassName(context.CodeGeneratorOptions),
+            ContainingType: mappedSourcePropertyType.ToExtensionClassName(context),
             MethodName: mappedSourcePropertyType.IsPrimitiveType() ? $"{methodPrefix}{mappedSourcePropertyType.Name}" : $"{methodPrefix}{propertyTypeName}",
             Type: property.Type.ToTypeMapping(),
             Explicit: false,

--- a/src/MapTo/Mappings/Handlers/NestedTypeConverterResolver.cs
+++ b/src/MapTo/Mappings/Handlers/NestedTypeConverterResolver.cs
@@ -14,7 +14,7 @@ internal class NestedTypeConverterResolver : ITypeConverterResolver
             null => ResolverResult.Undetermined<TypeConverterMapping>(),
             { TypeKind: TypeKind.Enum } => ResolverResult.Undetermined<TypeConverterMapping>(), // Is handled by EnumTypeConverterResolver
             _ => new TypeConverterMapping(
-                ContainingType: mappedSourcePropertyType.ToExtensionClassName(context.CodeGeneratorOptions),
+                ContainingType: mappedSourcePropertyType.ToExtensionClassName(context),
                 MethodName: mappedSourcePropertyType.IsPrimitiveType() ? $"{methodPrefix}{mappedSourcePropertyType.Name}" : $"{methodPrefix}{property.Type.Name}",
                 Type: property.Type.ToTypeMapping(),
                 Explicit: false,

--- a/src/MapTo/Mappings/Handlers/NestingTypeConverterResolverExtensions.cs
+++ b/src/MapTo/Mappings/Handlers/NestingTypeConverterResolverExtensions.cs
@@ -2,7 +2,16 @@
 
 internal static class NestingTypeConverterResolverExtensions
 {
-    public static string ToExtensionClassName(this INamedTypeSymbol typeSymbol, CodeGeneratorOptions options) => typeSymbol.IsPrimitiveType()
-        ? "System"
-        : $"{typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}{options.MapExtensionClassSuffix}";
+    public static string ToExtensionClassName(this INamedTypeSymbol typeSymbol, MappingContext context)
+    {
+        if (typeSymbol.IsPrimitiveType())
+        {
+            return "System";
+        }
+
+        var ns = context.TargetTypeSymbol.ContainingNamespace.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        var suffix = context.CodeGeneratorOptions.MapExtensionClassSuffix;
+
+        return $"{ns}.{typeSymbol.Name}{suffix}";
+    }
 }


### PR DESCRIPTION
Fix incorrect mapping when the source and target class names are the same.