### PR TITLE
Fix incorrect argument check when mapping nested properties from assembly

### DIFF
--- a/src/MapTo/Mappings/MapFromAttributeMapping.cs
+++ b/src/MapTo/Mappings/MapFromAttributeMapping.cs
@@ -36,7 +36,7 @@ internal static class MapFromAttributeMappingExtensions
                 .FirstOrDefault(
                     a => a.AttributeClass is not null &&
                          SymbolEqualityComparer.Default.Equals(a.AttributeClass.ConstructedFrom, context.KnownTypes.MapAttributeTypeSymbol) &&
-                         a.AttributeClass.TypeArguments[0].Equals(typeSymbol, SymbolEqualityComparer.Default));
+                         a.AttributeClass.TypeArguments[1].Equals(typeSymbol, SymbolEqualityComparer.Default));
         }
 
         return mapFromAttribute;

--- a/src/MapTo/Mappings/TypeMapping.cs
+++ b/src/MapTo/Mappings/TypeMapping.cs
@@ -23,7 +23,7 @@ internal readonly record struct TypeMapping(
 {
 #if DEBUG
     [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global", Justification = "Is for debugging purposes only.")]
-    internal ITypeSymbol OriginalTypeSymbol { get; init; }
+    internal ITypeSymbol OriginalTypeSymbol { get; init; } = null!;
 #endif
 }
 


### PR DESCRIPTION
Fix incorrect argument check when mapping nested properties from assembly