### PR TITLE
Add support for required init properties in object initializer mapping

### DIFF
--- a/src/MapTo/Generators/TypeInitializerGenerator.cs
+++ b/src/MapTo/Generators/TypeInitializerGenerator.cs
@@ -13,7 +13,8 @@ internal static class TypeInitializerGenerator
         var (sourceName, targetName, targetConstructor, targetProperties, options) = mapping;
         var sourceType = sourceName;
         var parameterName = sourceType.ToParameterNameCasing();
-        var hasObjectInitializer = targetProperties.Any(p => p.InitializationMode == PropertyInitializationMode.ObjectInitializer);
+        var hasObjectInitializer = targetProperties.Any(p =>
+            p.InitializationMode == PropertyInitializationMode.ObjectInitializer || (p.InitializationMode is PropertyInitializationMode.None && p.IsRequired));
 
         if (!targetConstructor.HasParameters)
         {


### PR DESCRIPTION
Updated the `WriteConstructorInitializer` method in `TypeInitializerGenerator.cs` to include required properties (`IsRequired`) with `PropertyInitializationMode.None` in the determination of whether an object initializer is needed. This ensures that required properties are properly initialized even when they lack explicit initialization modes.